### PR TITLE
XmlSerializer use jms element name if embed data array|Traversable

### DIFF
--- a/src/Hateoas/Serializer/XmlHalSerializer.php
+++ b/src/Hateoas/Serializer/XmlHalSerializer.php
@@ -42,17 +42,15 @@ class XmlHalSerializer implements XmlSerializerInterface
     public function serializeEmbedded(array $embeds, XmlSerializationVisitor $visitor, SerializationContext $context)
     {
         foreach ($embeds as $embed) {
-            $isDataArray = is_array($embed->getData()) && 0 === count(array_filter(array_keys($embed->getData()), 'is_string'));
-
-            if ($isDataArray) {
+            if ($embed->getData() instanceof \Traversable || is_array($embed->getData())) {
                 foreach ($embed->getData() as $data) {
                     $entryNode = $visitor->getDocument()->createElement('resource');
                     $visitor->getCurrentNode()->appendChild($entryNode);
                     $visitor->setCurrentNode($entryNode);
+                    $visitor->getCurrentNode()->setAttribute('rel', $embed->getRel());
 
                     $node = $context->accept($data);
                     if (null !== $node) {
-                        $visitor->getCurrentNode()->setAttribute('rel', $embed->getRel());
                         $visitor->getCurrentNode()->appendChild($node);
                     }
 

--- a/tests/Hateoas/HateoasBuilder.php
+++ b/tests/Hateoas/HateoasBuilder.php
@@ -7,8 +7,13 @@ use Hateoas\Model\Link;
 use Hateoas\Model\Resource;
 use Hateoas\HateoasBuilder as TestedHateoasBuilder;
 use tests\fixtures\AdrienBrault;
+use tests\fixtures\Computer;
+use tests\fixtures\Smartphone;
 use tests\TestCase;
 
+/**
+ * Contains functional tests
+ */
 class HateoasBuilder extends TestCase
 {
     public function test()
@@ -82,6 +87,10 @@ JSON
                 'Adrien',
                 'William',
             ), 'users'),
+            new Embed('tech', array(
+                new Computer('Mac'),
+                new Smartphone('iPhone'),
+            )),
             new Embed('test', 'test'),
         ), 'users');
 
@@ -103,6 +112,14 @@ JSON
     <entry><![CDATA[Adrien]]></entry>
     <entry><![CDATA[William]]></entry>
   </users>
+  <entry rel="tech">
+    <computer>
+      <name><![CDATA[Mac]]></name>
+    </computer>
+    <smartphone>
+      <name><![CDATA[iPhone]]></name>
+    </smartphone>
+  </entry>
   <entry rel="test"><![CDATA[test]]></entry>
 </users>
 
@@ -117,6 +134,12 @@ XML
   <link rel="next" href="/users?page=3"/>
   <resource rel="user"><![CDATA[Adrien]]></resource>
   <resource rel="user"><![CDATA[William]]></resource>
+  <resource rel="tech">
+    <name><![CDATA[Mac]]></name>
+  </resource>
+  <resource rel="tech">
+    <name><![CDATA[iPhone]]></name>
+  </resource>
   <resource rel="test"><![CDATA[test]]></resource>
 </resource>
 
@@ -124,7 +147,7 @@ XML
                 )
             ->string($hateoas->serialize($resource, 'json'))
                 ->isEqualTo(<<<JSON
-{"page":2,"limit":10,"_links":{"self":{"href":"\/users?page=2"},"next":{"href":"\/users?page=3"}},"_embedded":{"user":["Adrien","William"],"test":"test"}}
+{"page":2,"limit":10,"_links":{"self":{"href":"\/users?page=2"},"next":{"href":"\/users?page=3"}},"_embedded":{"user":["Adrien","William"],"tech":[{"name":"Mac"},{"name":"iPhone"}],"test":"test"}}
 JSON
                 )
         ;

--- a/tests/fixtures/Smartphone.php
+++ b/tests/fixtures/Smartphone.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace tests\fixtures;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\XmlRoot("smartphone")
+ */
+class Smartphone
+{
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
The behavior is a bit different than what the serializer does, because we now rely on an Interface. However this should make things better in most cases.
