### PR TITLE
Add SymfonyRequestHandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require-dev": {
         "atoum/atoum": "dev-master",
         "symfony/yaml": "~2.0",
-        "symfony/routing": "~2.0"
+        "symfony/routing": "~2.0",
+        "symfony/http-foundation": "~2.0"
     },
     "suggest": {
         "symfony/yaml": "To use yaml based configuration.",

--- a/src/Hateoas/Handler/SymfonyRequestHandler.php
+++ b/src/Hateoas/Handler/SymfonyRequestHandler.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Hateoas\Handler;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
+/**
+ * @author Adrien Brault <adrien.brault@gmail.com>
+ */
+class SymfonyRequestHandler implements HandlerInterface
+{
+    private static $requestProperties = array(
+        'attributes',
+        'request',
+        'query',
+        'server',
+        'cookies',
+        'headers',
+    );
+
+    /**
+     * @var PropertyAccessor
+     */
+    private $propertyAccessor;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    public function __construct(PropertyAccessor $propertyAccessor = null, Request $request = null)
+    {
+        $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
+        $this->request = $request;
+    }
+
+    /**
+     * This setters should come in handy with symfony's DI request scope
+     *
+     * @param Request $request
+     */
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($value, $data)
+    {
+        if (null === $this->request) {
+            throw new \RuntimeException('The request was not set on the SymfonyRequestHandler.');
+        }
+
+        if (!preg_match('/(?P<property>[^.]+)([.](?P<key>.+))?/', $value, $matches)) {
+            return null;
+        }
+
+        $property = $matches['property'];
+
+        if (isset($matches['key'])) {
+            if (!in_array($property, self::$requestProperties)) {
+                throw new \InvalidArgumentException(
+                    sprintf('The property "%s" is not supported on the Request.', $property)
+                );
+            }
+
+            return $this->request->{$property}->get($matches['key']);
+        }
+
+        return $this->propertyAccessor->getValue($this->request, $property);
+    }
+}

--- a/tests/Hateoas/Handler/SymfonyRequestHandler.php
+++ b/tests/Hateoas/Handler/SymfonyRequestHandler.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace tests\Hateoas\Handler;
+
+use tests\TestCase;
+use Hateoas\Handler\SymfonyRequestHandler as TestedSymfonyRequestHandler;
+
+class SymfonyRequestHandler extends TestCase
+{
+    public function testNoRequest()
+    {
+        $requestHandler = new TestedSymfonyRequestHandler();
+
+        $this
+            ->exception(function () use ($requestHandler) {
+                $requestHandler->transform('', null);
+            })
+                ->isInstanceOf('RuntimeException')
+                ->hasMessage('The request was not set on the SymfonyRequestHandler.')
+        ;
+    }
+
+    public function testInvalidValue()
+    {
+        $request = new \mock\Symfony\Component\HttpFoundation\Request;
+        $requestHandler = new TestedSymfonyRequestHandler();
+        $requestHandler->setRequest($request);
+
+        $this
+            ->variable($requestHandler->transform('', null))
+                ->isNull()
+        ;
+    }
+
+    public function testInvalidProperty()
+    {
+        $request = new \mock\Symfony\Component\HttpFoundation\Request;
+        $requestHandler = new TestedSymfonyRequestHandler();
+        $requestHandler->setRequest($request);
+
+        $this
+            ->exception(function () use ($requestHandler) {
+                $requestHandler->transform('fake.something', null);
+            })
+                ->isInstanceOf('InvalidArgumentException')
+                ->hasMessage('The property "fake" is not supported on the Request.')
+        ;
+    }
+
+    public function testMethodsAndProperties()
+    {
+        $request = new \mock\Symfony\Component\HttpFoundation\Request();
+        $request->query->set('page', $page = 5);
+        $request->request->set('age', $age = 2044);
+        $request->attributes->set('_route', $route = 'user_all');
+        $request->cookies->set('PHPSESSID', $sessId = 'abcd');
+        $request->server->set('SERVER_NAME', $serverName = 'hateoas');
+        $request->headers->set('X-Hello', $hello = 'adrien');
+        $request->setRequestFormat($requestFormat = 'application/json');
+        $requestHandler = new TestedSymfonyRequestHandler();
+        $requestHandler->setRequest($request);
+
+        $this
+            ->variable($requestHandler->transform('query.page', null))
+                ->isEqualTo($page)
+            ->variable($requestHandler->transform('request.age', null))
+                ->isEqualTo($age)
+            ->variable($requestHandler->transform('attributes._route', null))
+                ->isEqualTo($route)
+            ->variable($requestHandler->transform('cookies.PHPSESSID', null))
+                ->isEqualTo($sessId)
+            ->variable($requestHandler->transform('server.SERVER_NAME', null))
+                ->isEqualTo($serverName)
+            ->variable($requestHandler->transform('headers.X-Hello', null))
+                ->isEqualTo($hello)
+            ->variable($requestHandler->transform('requestFormat', null))
+                ->isEqualTo($requestFormat)
+        ;
+    }
+}


### PR DESCRIPTION
So you'd configure the builder:

``` php
$hateoasBuilder->setDefaultHandlers();
$hateoasBuilder->setHandler('Request', $symfonyRequestHandler);
```

And you would then be able to use `@Request.requestFormat`, `@Request.query.page`, etc along with the built in `@this.id` ...

This fixes #51 cc @lsmith77
