### PR TITLE
ExpressionEvaluator evaluateArray is now recursive.

### DIFF
--- a/src/Hateoas/Expression/ExpressionEvaluator.php
+++ b/src/Hateoas/Expression/ExpressionEvaluator.php
@@ -59,7 +59,7 @@ class ExpressionEvaluator
         $newArray = array();
         foreach ($array as $key => $value) {
             $key   = $this->evaluate($key, $data);
-            $value = $this->evaluate($value, $data);
+            $value = is_array($value) ? $this->evaluateArray($value, $data) : $this->evaluate($value, $data);
 
             $newArray[$key] = $value;
         }

--- a/tests/Hateoas/Expression/ExpressionEvaluator.php
+++ b/tests/Hateoas/Expression/ExpressionEvaluator.php
@@ -70,14 +70,14 @@ class ExpressionEvaluator extends TestCase
 
         $array = array(
             'expr(a)' => 'expr(aa)',
-            'hello' => 'expr(aaa)',
+            'hello' => array('expr(aaa)'),
         );
 
         $this
             ->array($expressionEvaluator->evaluateArray($array, $data))
                 ->isEqualTo(array(
                     1 => 2,
-                    'hello' => 3,
+                    'hello' => array(3),
                 ))
             ->mock($expressionLanguageMock)
                 ->call('parse')


### PR DESCRIPTION
This is needed because in some cases you need nested arrays for symfony route parameters.
