### PR TITLE
Metadata madness

### DIFF
--- a/src/Hateoas/Configuration/Metadata/ClassMetadata.php
+++ b/src/Hateoas/Configuration/Metadata/ClassMetadata.php
@@ -23,6 +23,14 @@ class ClassMetadata extends MergeableClassMetadata implements ClassMetadataInter
     private $relationProviders = array();
 
     /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getRelations()

--- a/src/Hateoas/Configuration/Metadata/ClassMetadataInterface.php
+++ b/src/Hateoas/Configuration/Metadata/ClassMetadataInterface.php
@@ -11,6 +11,11 @@ use Hateoas\Configuration\RelationProvider;
 interface ClassMetadataInterface
 {
     /**
+     * @return string
+     */
+    public function getName();
+
+    /**
      * @return Relation[]
      */
     public function getRelations();
@@ -19,4 +24,14 @@ interface ClassMetadataInterface
      * @return RelationProvider[]
      */
     public function getRelationProviders();
+
+    /**
+     * @param Relation $relation
+     */
+    public function addRelation(Relation $relation);
+
+    /**
+     * @param RelationProvider $relationProvider
+     */
+    public function addRelationProvider(RelationProvider $relationProvider);
 }

--- a/src/Hateoas/Configuration/Metadata/ConfigurationExtensionInterface.php
+++ b/src/Hateoas/Configuration/Metadata/ConfigurationExtensionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Hateoas\Configuration\Metadata;
+
+/**
+ * @author Adrien Brault <adrien.brault@gmail.com>
+ */
+interface ConfigurationExtensionInterface
+{
+    public function decorate(ClassMetadataInterface $classMetadata);
+}

--- a/src/Hateoas/Configuration/Metadata/Driver/ExtensionDriver.php
+++ b/src/Hateoas/Configuration/Metadata/Driver/ExtensionDriver.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Hateoas\Configuration\Metadata\Driver;
+
+use Hateoas\Configuration\ConfigurationExtensionInterface;
+use Hateoas\Configuration\Metadata\ClassMetadata;
+use Metadata\Driver\DriverInterface;
+
+/**
+ * @author Adrien Brault <adrien.brault@gmail.com>
+ */
+class ExtensionDriver implements DriverInterface
+{
+    /**
+     * @var DriverInterface
+     */
+    private $delegate;
+
+    /**
+     * @var ConfigurationExtensionInterface[]
+     */
+    private $extensions;
+
+    public function __construct(
+        DriverInterface $delegate,
+        array $extensions
+    ) {
+        $this->delegate = $delegate;
+        $this->extensions = $extensions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadMetadataForClass(\ReflectionClass $class)
+    {
+        $metadata = $this->delegate->loadMetadataForClass($class);
+        $newMetadata = false;
+
+        if (empty($this->extensions)) {
+            return $metadata;
+        }
+
+        if (null === $metadata) {
+            $metadata = new ClassMetadata($class->getName());
+            $newMetadata = true;
+        }
+
+        foreach ($this->extensions as $extension) {
+            $extension->decorate($metadata);
+        }
+
+        if ($newMetadata && count($metadata->getRelations()) < 1 && count($metadata->getRelationProviders()) < 1) {
+            $metadata = null;
+        }
+
+        return $metadata;
+    }
+}

--- a/src/Hateoas/Configuration/RelationsRepository.php
+++ b/src/Hateoas/Configuration/RelationsRepository.php
@@ -22,11 +22,6 @@ class RelationsRepository
     private $relationProvider;
 
     /**
-     * @var array fqcn => Relation[]
-     */
-    private $classesRelations = array();
-
-    /**
      * @param MetadataFactoryInterface $metadataFactory
      * @param RelationProvider         $relationProvider
      */
@@ -49,28 +44,8 @@ class RelationsRepository
             $relations = array_merge($relations, $classMetadata->getRelations());
         }
 
-        $class = strtolower(ClassUtils::getClass($object));
-        if (isset($this->classesRelations[$class])) {
-            $relations = array_merge($relations, $this->classesRelations[$class]);
-        }
-
         $relations = array_merge($relations, $this->relationProvider->getRelations($object));
 
         return $relations;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addClassRelation($class, Relation $relation)
-    {
-        $class = strtolower(ClassUtils::getRealClass($class));
-
-        $this->classesRelations[$class][] = $relation;
-    }
-
-    private function getObjectId($object)
-    {
-        return spl_object_hash($object);
     }
 }

--- a/src/Hateoas/HateoasBuilder.php
+++ b/src/Hateoas/HateoasBuilder.php
@@ -4,7 +4,9 @@ namespace Hateoas;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\FileCacheReader;
+use Hateoas\Configuration\Metadata\ConfigurationExtensionInterface;
 use Hateoas\Configuration\Metadata\Driver\AnnotationDriver;
+use Hateoas\Configuration\Metadata\Driver\ExtensionDriver;
 use Hateoas\Configuration\Metadata\Driver\YamlDriver;
 use Hateoas\Configuration\Provider\Resolver\MethodResolver;
 use Hateoas\Configuration\Provider\Resolver\ChainResolver;
@@ -65,6 +67,8 @@ class HateoasBuilder
      * @var UrlGeneratorRegistry
      */
     private $urlGeneratorRegistry;
+
+    private $configurationExtensions = array();
 
     private $chainResolver;
 
@@ -233,6 +237,11 @@ class HateoasBuilder
         return $this->expressionLanguage;
     }
 
+    public function addConfigurationExtension(ConfigurationExtensionInterface $configurationExtension)
+    {
+        $this->configurationExtensions[] = $configurationExtension;
+    }
+
     public function setDebug($bool)
     {
         $this->debug = (boolean) $bool;
@@ -396,6 +405,8 @@ class HateoasBuilder
         } else {
             $metadataDriver = new AnnotationDriver($annotationReader);
         }
+
+        $metadataDriver = new ExtensionDriver($metadataDriver, $this->configurationExtensions);
 
         $metadataFactory = new MetadataFactory($metadataDriver, null, $this->debug);
         $metadataFactory->setIncludeInterfaces($this->includeInterfaceMetadata);

--- a/tests/Hateoas/Configuration/Metadata/Driver/ExtensionDriver.php
+++ b/tests/Hateoas/Configuration/Metadata/Driver/ExtensionDriver.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace tests\Hateoas\Configuration\Metadata\Driver;
+
+use Hateoas\Configuration\Metadata\ClassMetadata;
+use Hateoas\Configuration\Metadata\ClassMetadataInterface;
+use Hateoas\Configuration\Metadata\Driver\ExtensionDriver as TestedExtensionDriver;
+use Hateoas\Configuration\Relation;
+use tests\TestCase;
+
+class ExtensionDriver extends TestCase
+{
+    public function testDoesNothingIfNoExtension()
+    {
+        $delegateDriver = new \mock\Metadata\Driver\DriverInterface();
+        $classMetadata = new ClassMetadata(get_class($this));
+        $i = 0;
+        $delegateDriver->getMockController()->loadMetadataForClass = function () use (&$i, $classMetadata) {
+            return $i++ < 1 ? $classMetadata : null;
+        };
+
+        $extensionDriver = new TestedExtensionDriver($delegateDriver, array());
+        $reflectionClass = new \ReflectionClass(get_class($this));
+
+        $this
+            ->variable($extensionDriver->loadMetadataForClass($reflectionClass))
+                ->isEqualTo($classMetadata)
+            ->variable($extensionDriver->loadMetadataForClass($reflectionClass))
+                ->isNull()
+            ->mock($delegateDriver)
+                ->call('loadMetadataForClass')
+                    ->withArguments($reflectionClass)
+                    ->twice()
+        ;
+    }
+
+    public function testExtensions()
+    {
+        $extensions = array(
+            new \mock\Hateoas\Configuration\Metadata\ConfigurationExtensionInterface(),
+            new \mock\Hateoas\Configuration\Metadata\ConfigurationExtensionInterface(),
+        );
+        $classMetadata = new ClassMetadata(get_class($this));
+        $delegateDriver = new \mock\Metadata\Driver\DriverInterface();
+        $delegateDriver->getMockController()->loadMetadataForClass = function () use ($classMetadata) {
+            return $classMetadata;
+        };
+
+        $extensionDriver = new TestedExtensionDriver($delegateDriver, $extensions);
+        $reflectionClass = new \ReflectionClass(get_class($this));
+
+        $this
+            ->variable($extensionDriver->loadMetadataForClass($reflectionClass))
+                ->isIdenticalTo($classMetadata)
+            ->mock($extensions[0])
+                ->call('decorate')
+                    ->withArguments($classMetadata)
+                    ->once()
+            ->mock($extensions[1])
+                ->call('decorate')
+                    ->withArguments($classMetadata)
+                    ->once()
+        ;
+    }
+
+    public function testDelegateReturnsNullAndNoExtensions()
+    {
+        $delegateDriver = new \mock\Metadata\Driver\DriverInterface();
+        $extensionDriver = new TestedExtensionDriver($delegateDriver, array());
+        $reflectionClass = new \ReflectionClass(get_class($this));
+
+        $this
+            ->variable($extensionDriver->loadMetadataForClass($reflectionClass))
+                ->isNull()
+        ;
+    }
+
+    public function testDelegateReturnsNullAndExtensionsDoNothing()
+    {
+        $extension = new \mock\Hateoas\Configuration\Metadata\ConfigurationExtensionInterface();
+        $delegateDriver = new \mock\Metadata\Driver\DriverInterface();
+
+        $extensionDriver = new TestedExtensionDriver($delegateDriver, array($extension));
+        $reflectionClass = new \ReflectionClass(get_class($this));
+
+        $this
+            ->variable($extensionDriver->loadMetadataForClass($reflectionClass))
+                ->isNull()
+            ->mock($extension)
+                ->call('decorate')
+                    ->once()
+        ;
+    }
+
+    public function testDelegateReturnsNullAndExtensionsAddRelations()
+    {
+        $extension = new \mock\Hateoas\Configuration\Metadata\ConfigurationExtensionInterface();
+        $extension->getMockController()->decorate = function (ClassMetadataInterface $classMetadata) {
+            $classMetadata->addRelation(new Relation('foo', 'bar'));
+        };
+        $delegateDriver = new \mock\Metadata\Driver\DriverInterface();
+
+        $extensionDriver = new TestedExtensionDriver($delegateDriver, array($extension));
+        $reflectionClass = new \ReflectionClass(get_class($this));
+
+        $this
+            ->object($extensionDriver->loadMetadataForClass($reflectionClass))
+                ->isInstanceOf('Hateoas\Configuration\Metadata\ClassMetadataInterface')
+            ->mock($extension)
+                ->call('decorate')
+                    ->once()
+        ;
+    }
+}

--- a/tests/Hateoas/Configuration/RelationsRepository.php
+++ b/tests/Hateoas/Configuration/RelationsRepository.php
@@ -22,31 +22,6 @@ class RelationsRepository extends TestCase
         ;
     }
 
-    public function testAddClassRelation()
-    {
-        $relationsRepository = new TestedRelationsRepository(
-            $this->mockMetadataFactory(),
-            $this->mockRelationProvider()
-        );
-        $object1 = new \StdClass();
-        $object2 = new \StdClass();
-
-        $relation1 = new Relation_('', '');
-        $relation2 = new Relation_('', '');
-
-        $relationsRepository->addClassRelation('StdClass', $relation1);
-        $relationsRepository->addClassRelation('StdClass', $relation2);
-
-        $this
-            ->array($relationsRepository->getRelations($object1))
-                ->contains($relation1)
-                ->contains($relation2)
-            ->array($relationsRepository->getRelations($object2))
-                ->contains($relation1)
-                ->contains($relation2)
-        ;
-    }
-
     public function testMetadataFactoryRelations()
     {
         $relations = array(


### PR DESCRIPTION
Fixes #70

I chose the "powerful decorate way" for the ConfigurationExtensions because it may be useful to detect if there is already a self link etc.

The bundle should use tag to register these extension, and allow a priority on the tags.
