### PR TITLE
Fix cache rebuild for xml and yaml drivers

### DIFF
--- a/src/Hateoas/Configuration/Metadata/Driver/XmlDriver.php
+++ b/src/Hateoas/Configuration/Metadata/Driver/XmlDriver.php
@@ -37,6 +37,8 @@ class XmlDriver extends AbstractFileDriver
         }
 
         $classMetadata = new ClassMetadata($name);
+        $classMetadata->fileResources[] = $file;
+        $classMetadata->fileResources[] = $class->getFileName();
 
         if ($exists[0]->attributes(self::NAMESPACE_URI)->providers) {
             $providers = preg_split('/\s*,\s*/', (string) $exists[0]->attributes(self::NAMESPACE_URI)->providers);

--- a/src/Hateoas/Configuration/Metadata/Driver/YamlDriver.php
+++ b/src/Hateoas/Configuration/Metadata/Driver/YamlDriver.php
@@ -29,6 +29,8 @@ class YamlDriver extends AbstractFileDriver
 
         $config        = $config[$name];
         $classMetadata = new ClassMetadata($name);
+        $classMetadata->fileResources[] = $file;
+        $classMetadata->fileResources[] = $class->getFileName();
 
         if (isset($config['relations'])) {
             foreach ($config['relations'] as $relation) {


### PR DESCRIPTION
ATM the metadata is missing fileResources information and because of that when metadata is changed the cached metadata is not rebuilt.
