### PR TITLE
fixed Route annotation in UrlGenerator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ use Hateoas\Configuration\Annotation as Hateoas;
 /**
  * @Hateoas\Relation(
  *      "self",
- *      href = @Route(
+ *      href = @Hateoas\Route(
  *          "user_get",
  *          parameters = {
  *              "id" = "expr(object.getId())"


### PR DESCRIPTION
Fixed a little error in the doc: the `@Route` annotation should be `@Hateoas\Route`
