### PR TITLE
Add missing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,7 +817,7 @@ under some circumstances:
  *     href = @Hateoas\Route(
  *         "user_get",
  *         parameters = { "id" = "expr(object.getManager().getId())" }
- *     )
+ *     ),
  *     exclusion = @Hateoas\Exclusion(excludeIf = "expr(null === object.getManager())")
  * )
  */


### PR DESCRIPTION
Fixes the example code in the _@Exclusion_ section of the README file.
