### PR TITLE
[WIP] Add JsonApiSerializer

### DIFF
--- a/src/Hateoas/Serializer/JsonApiSerializer.php
+++ b/src/Hateoas/Serializer/JsonApiSerializer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Hateoas\Serializer;
+
+use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\SerializationContext;
+
+/**
+ * @author William Durand <william.durand1@gmail.com>
+ */
+class JsonApiSerializer implements JsonSerializerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function serializeLinks(array $links, JsonSerializationVisitor $visitor, SerializationContext $context)
+    {
+        $serializedLinks = array();
+        $topLevelSerializedLinks = array();
+
+        foreach ($links as $link) {
+            $serializedLink = array_merge(array(
+                'href' => $link->getHref(),
+            ), $link->getAttributes());
+
+            if (isset($serializedLink['topLevel']) && true === $serializedLink['topLevel']) {
+                unset($serializedLink['topLevel']);
+                $topLevelSerializedLinks[$link->getRel()] = $serializedLink;
+
+                continue;
+            }
+
+            if (!isset($serializedLinks[$link->getRel()])) {
+                $serializedLinks[$link->getRel()] = $serializedLink['href'];
+            } else {
+                $serializedLinks[$link->getRel()][] = $serializedLink['href'];
+            }
+        }
+
+        $visitor->addData('links', $serializedLinks);
+        $visitor->setRoot(array('links' => $topLevelSerializedLinks));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serializeEmbeds(array $embeds, JsonSerializationVisitor $visitor, SerializationContext $context)
+    {
+        $serializedEmbeds = array();
+        foreach ($embeds as $embed) {
+            $serializedEmbeds[$embed->getRel()] = $context->accept($embed->getData());
+        }
+
+        $visitor->setRoot(array('linked' => $serializedEmbeds));
+    }
+}


### PR DESCRIPTION
URL based, see: http://jsonapi.org/format/#url-based-json-api

### Limitations

This serializer works but it requires a few conditions:

1) The serializer MUST take an array to serialize, not just a resource, because of the JSON API specification:

```php
$user = new User(123);

// we can't just pass `$user` here
$hateoas->serialize(array('users' => $user), 'json');
```

2) `href` values for **link** relations MUST be identifiers (still because of the JSON API spec):

```php
/**
 * @Hateoas\Relation("posts", href = "expr(object.getPostIds())")
 */
class User
{
    public function getPostIds()
    {
        return [ 4, 5, 10 ];
    }
}
```

The output would be:

```json
{
    "users": [{
        "id": 123,
        "links": {
            "posts": [ 4, 5, 10 ]
        }
    }]
}
```

3) In order to define **top level links**, you MUST set a `topLevel` attribute:

```php
/**
 * @Hateoas\Relation(
 *     "posts",
 *     href = "http://example.com/{id}/posts",
 *     attributes = { "topLevel" = true, "type" = "posts" }
 * )
 *
 * ...
 */
class User
{
    // ...
}
```

The output would be:

```json
{
    "links": {
        "posts": {
            "href": "http://example.com/{id}/posts",
            "type": "posts"
        }
    },
    "users": {
        "id": 123,
        "links": {
            "posts": [
                4,
                5,
                10
            ]
        }
    }
}
```

I guess **these requirements are acceptable**.

WDYT?