### PR TITLE
Forward some method calls to the SerializerBuilder

### DIFF
--- a/src/Hateoas/HateoasBuilder.php
+++ b/src/Hateoas/HateoasBuilder.php
@@ -157,7 +157,8 @@ class HateoasBuilder
             ),
         );
 
-        $this->serializerBuilder
+        $this
+            ->serializerBuilder
             ->addDefaultListeners()
             ->configureListeners(function (EventDispatcherInterface $dispatcher) use ($eventSubscribers) {
                 foreach ($eventSubscribers as $eventSubscriber) {
@@ -298,6 +299,8 @@ class HateoasBuilder
     {
         $this->debug = (boolean) $debug;
 
+        $this->serializerBuilder->setDebug($debug);
+
         return $this;
     }
 
@@ -316,7 +319,9 @@ class HateoasBuilder
             throw new \InvalidArgumentException(sprintf('The cache directory "%s" is not writable.', $dir));
         }
 
-        $this->cacheDir = $dir;
+        $this->cacheDir = $dir . '/hateoas';
+
+        $this->serializerBuilder->setCacheDir($dir . '/serializer');
 
         return $this;
     }
@@ -329,6 +334,8 @@ class HateoasBuilder
     public function includeInterfaceMetadata($include)
     {
         $this->includeInterfaceMetadata = (boolean) $include;
+
+        $this->serializerBuilder->includeInterfaceMetadata($include);
 
         return $this;
     }
@@ -351,6 +358,8 @@ class HateoasBuilder
         }
 
         $this->metadataDirs = $namespacePrefixToDirMap;
+
+        $this->serializerBuilder->setMetadataDirs($namespacePrefixToDirMap);
 
         return $this;
     }
@@ -390,6 +399,8 @@ class HateoasBuilder
 
         $this->metadataDirs[$namespacePrefix] = $dir;
 
+        $this->serializerBuilder->addMetadataDir($dir, $namespacePrefix);
+
         return $this;
     }
 
@@ -405,6 +416,8 @@ class HateoasBuilder
         foreach ($namespacePrefixToDirMap as $prefix => $dir) {
             $this->addMetadataDir($dir, $prefix);
         }
+
+        $this->serializerBuilder->addMetadataDirs($namespacePrefixToDirMap);
 
         return $this;
     }
@@ -428,6 +441,8 @@ class HateoasBuilder
         }
 
         $this->metadataDirs[$namespacePrefix] = $dir;
+
+        $this->serializerBuilder->replaceMetadataDir(dir, $namespacePrefix);
 
         return $this;
     }


### PR DESCRIPTION
In order to configure it without having to create an instance of SerializerBuilder.

The cache directory is now namespaced for Hateoas and Serializer libs as
they can't share the same cache directory.
