### PR TITLE
Support curies in JsonHalSerializer

### DIFF
--- a/src/Hateoas/Serializer/JsonHalSerializer.php
+++ b/src/Hateoas/Serializer/JsonHalSerializer.php
@@ -21,7 +21,7 @@ class JsonHalSerializer implements JsonSerializerInterface
                 'href' => $link->getHref(),
             ), $link->getAttributes());
 
-            if (!isset($serializedLinks[$link->getRel()])) {
+            if (!isset($serializedLinks[$link->getRel()]) && 'curies' !== $link->getRel()) {
                 $serializedLinks[$link->getRel()] = $serializedLink;
             } elseif (isset($serializedLinks[$link->getRel()]['href'])) {
                 $serializedLinks[$link->getRel()] = array(

--- a/tests/Hateoas/Tests/Serializer/JsonHalSerializerTest.php
+++ b/tests/Hateoas/Tests/Serializer/JsonHalSerializerTest.php
@@ -81,4 +81,79 @@ class JsonHalSerializerTest extends TestCase
             $contextProphecy->reveal()
         );
     }
+
+    public function testSerializeCuriesWithOneLinkShouldBeAnArray()
+    {
+        $links = array(
+            new Link('self',   '/users/42'),
+            new Link('curies', '/rels/{rel}', array('name' => 'p')),
+        );
+
+        $expectedSerializedLinks = array(
+            'self' => array(
+                'href' => '/users/42',
+            ),
+            'curies' => array(
+                array(
+                    'href' => '/rels/{rel}',
+                    'name' => 'p',
+                ),
+            ),
+        );
+
+        $contextProphecy = $this->prophesize('JMS\Serializer\SerializationContext');
+
+        $jsonSerializationVisitorProphecy = $this->prophesize('JMS\Serializer\JsonSerializationVisitor');
+        $jsonSerializationVisitorProphecy
+            ->addData('_links', $expectedSerializedLinks)
+            ->shouldBeCalledTimes(1)
+        ;
+
+        $jsonHalSerializer = new JsonHalSerializer();
+        $jsonHalSerializer->serializeLinks(
+            $links,
+            $jsonSerializationVisitorProphecy->reveal(),
+            $contextProphecy->reveal()
+        );
+    }
+
+    public function testSerializeCuriesWithMultipleEntriesShouldBeAnArray()
+    {
+        $links = array(
+            new Link('self',   '/users/42'),
+            new Link('curies', '/rels/{rel}', array('name' => 'p')),
+            new Link('curies', '/foo/rels/{rel}', array('name' => 'foo')),
+        );
+
+        $expectedSerializedLinks = array(
+            'self' => array(
+                'href' => '/users/42',
+            ),
+            'curies' => array(
+                array(
+                    'href' => '/rels/{rel}',
+                    'name' => 'p',
+                ),
+                array(
+                    'href' => '/foo/rels/{rel}',
+                    'name' => 'foo',
+                ),
+            ),
+        );
+
+        $contextProphecy = $this->prophesize('JMS\Serializer\SerializationContext');
+
+        $jsonSerializationVisitorProphecy = $this->prophesize('JMS\Serializer\JsonSerializationVisitor');
+        $jsonSerializationVisitorProphecy
+            ->addData('_links', $expectedSerializedLinks)
+            ->shouldBeCalledTimes(1)
+        ;
+
+        $jsonHalSerializer = new JsonHalSerializer();
+        $jsonHalSerializer->serializeLinks(
+            $links,
+            $jsonSerializationVisitorProphecy->reveal(),
+            $contextProphecy->reveal()
+        );
+    }
 }


### PR DESCRIPTION
So, according to the [HAL spec](http://stateless.co/hal_specification.html), `curies` is a special rel name (like `self`), and should always be an array, no matter how many links there are. This PR fixes this edge case.
