### PR TITLE
Fixed PHPDoc for HateoasBuilder:create function

### DIFF
--- a/src/Hateoas/HateoasBuilder.php
+++ b/src/Hateoas/HateoasBuilder.php
@@ -101,7 +101,7 @@ class HateoasBuilder
     /**
      * @param SerializerBuilder $serializerBuilder
      *
-     * @return Hateoas
+     * @return HateoasBuilder
      */
     public static function create(SerializerBuilder $serializerBuilder = null)
     {


### PR DESCRIPTION
This fixes the PHPDoc return type for `HateoasBuilder:create`. IDEs autocompletion was returning the wrong class, thus leading to incoherences.
