### PR TITLE
Added check on property to avoid notices in HHVM.

### DIFF
--- a/src/Hateoas/Serializer/Metadata/InlineDeferrer.php
+++ b/src/Hateoas/Serializer/Metadata/InlineDeferrer.php
@@ -72,7 +72,7 @@ class InlineDeferrer implements JMSSerializerMetadataAwareInterface
         }
 
         if (
-            $metadataStack->count() > 0 && $metadataStack[0]->inline
+            $metadataStack->count() > 0 && isset($metadataStack[0]->inline) && $metadataStack[0]->inline
             && $this->serializerMetadataFactory->getMetadataForClass(get_class($parentObject)) === $metadataStack[1]
         ) {
             return $parentObject;


### PR DESCRIPTION
The direct access on the inline property of ClassMetadata lead to a notice in the HHVM. Added an isset statement before to avoid that.
