### PR TITLE
Add OffsetRepresentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ The library provides several classes in the `Hateoas\Representation\*`
 namespace to help you with common tasks. These are simple classes configured
 with the library's annotations.
 
-The `PaginatedRepresentation` and `CollectionRepresentation` classes are
+The `PaginatedRepresentation`, `OffsetRepresentation` and `CollectionRepresentation` classes are
 probably the most interesting ones. These are helpful when your resource is
 actually a collection of resources (e.g. `/users` is a collection of users).
 These help you represent the collection and add pagination and limits:
@@ -354,16 +354,17 @@ $paginatedCollection = new PaginatedRepresentation(
     new CollectionRepresentation(
         array($user1, $user2, ...),
         'users', // embedded rel
-        'users' // xml element name
+        'users'  // xml element name
     ),
     'user_list', // route
     array(), // route parameters
-    1, // page
-    20, // limit
-    4, // total pages
+    1,       // page number
+    20,      // limit
+    4,       // total pages
     'page',  // page route parameter name, optional, defaults to 'page'
     'limit', // limit route parameter name, optional, defaults to 'limit'
-    false    // generate relative URIs
+    false,   // generate relative URIs, optional, defaults to `false`
+    75       // total collection size, optional, defaults to `null`
 );
 
 $json = $hateoas->serialize($paginatedCollection, 'json');
@@ -375,6 +376,9 @@ collection resources rel, and the xml root element name.
 
 The `PaginatedRepresentation` is designed to add `self`, `first`, and when
 possible `last`, `next`, and `previous` links.
+
+The `OffsetRepresentation` works just like `PaginatedRepresentation` but is useful
+when pagination is expressed by `offset`, `limit` and `total`.
 
 The `RouteAwareRepresentation` adds a `self` relation based on a given route.
 

--- a/src/Hateoas/Representation/AbstractSegmentedRepresentation.php
+++ b/src/Hateoas/Representation/AbstractSegmentedRepresentation.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Hateoas\Representation;
+
+use Hateoas\Configuration\Annotation as Hateoas;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\ExclusionPolicy("all")
+ *
+ * @author Premi Giorgio <giosh94mhz@gmail.com>
+ */
+abstract class AbstractSegmentedRepresentation extends RouteAwareRepresentation
+{
+    /**
+     * @var int
+     *
+     * @Serializer\Expose
+     * @Serializer\Type("integer")
+     * @Serializer\XmlAttribute
+     */
+    private $limit;
+
+    /**
+     * @var int
+     *
+     * @Serializer\Expose
+     * @Serializer\Type("integer")
+     * @Serializer\XmlAttribute
+     */
+    private $total;
+
+    /**
+     * @var string
+     */
+    private $limitParameterName;
+
+    public function __construct(
+        $inline,
+        $route,
+        array $parameters        = array(),
+        $limit,
+        $total                   = null,
+        $limitParameterName      = null,
+        $absolute                = false
+    ) {
+        parent::__construct($inline, $route, $parameters, $absolute);
+
+        $this->total               = $total;
+        $this->limit               = $limit;
+        $this->limitParameterName  = $limitParameterName ?: 'limit';
+    }
+
+    /**
+     * @return int
+     */
+    public function getLimit()
+    {
+        return $this->limit;
+    }
+
+    /**
+     * @param  null  $offset
+     * @param  null  $limit
+     * @return array
+     */
+    public function getParameters($limit = null)
+    {
+        $parameters = parent::getParameters();
+
+        $parameters[$this->limitParameterName] = null === $limit ? $this->getLimit() : $limit;
+
+        return $parameters;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotal()
+    {
+        return $this->total;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLimitParameterName()
+    {
+        return $this->limitParameterName;
+    }
+
+    /**
+     * @param string $paramName
+     */
+    protected function moveParameterToEnd(array &$parameters, $key)
+    {
+        if (! array_key_exists($key, $parameters)) {
+            return;
+        }
+
+        $value = $parameters[$key];
+        unset($parameters[$key]);
+        $parameters[$key] = $value;
+    }
+}

--- a/src/Hateoas/Representation/OffsetRepresentation.php
+++ b/src/Hateoas/Representation/OffsetRepresentation.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Hateoas\Representation;
+
+use Hateoas\Configuration\Annotation as Hateoas;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\ExclusionPolicy("all")
+ * @Serializer\XmlRoot("collection")
+ * @Serializer\AccessorOrder("custom", custom = {"offset", "limit", "total"})
+ *
+ * @Hateoas\Relation(
+ *      "first",
+ *      href = @Hateoas\Route(
+ *          "expr(object.getRoute())",
+ *          parameters = "expr(object.getParameters(0))",
+ *          absolute = "expr(object.isAbsolute())"
+ *      )
+ * )
+ * @Hateoas\Relation(
+ *      "last",
+ *      href = @Hateoas\Route(
+ *          "expr(object.getRoute())",
+ *          parameters = "expr(object.getParameters((object.getTotal() - 1) - (object.getTotal() - 1) % object.getLimit()))",
+ *          absolute = "expr(object.isAbsolute())"
+ *      ),
+ *      exclusion = @Hateoas\Exclusion(
+ *          excludeIf = "expr(object.getTotal() === null)"
+ *      )
+ * )
+ * @Hateoas\Relation(
+ *      "next",
+ *      href = @Hateoas\Route(
+ *          "expr(object.getRoute())",
+ *          parameters = "expr(object.getParameters(object.getOffset() + object.getLimit()))",
+ *          absolute = "expr(object.isAbsolute())"
+ *      ),
+ *      exclusion = @Hateoas\Exclusion(
+ *          excludeIf = "expr(object.getTotal() !== null && (object.getOffset() + object.getLimit()) >= object.getTotal())"
+ *      )
+ * )
+ * @Hateoas\Relation(
+ *      "previous",
+ *      href = @Hateoas\Route(
+ *          "expr(object.getRoute())",
+ *          parameters = "expr(object.getParameters((object.getOffset() > object.getLimit()) ? object.getOffset() - object.getLimit() : 0))",
+ *          absolute = "expr(object.isAbsolute())"
+ *      ),
+ *      exclusion = @Hateoas\Exclusion(
+ *          excludeIf = "expr(! object.getOffset())"
+ *      )
+ * )
+ *
+ * @author Premi Giorgio <giosh94mhz@gmail.com>
+ */
+class OffsetRepresentation extends AbstractSegmentedRepresentation
+{
+    /**
+     * @var int
+     *
+     * @Serializer\Expose
+     * @Serializer\XmlAttribute
+     */
+    private $offset;
+
+    /**
+     * @var string
+     */
+    private $offsetParameterName;
+
+    public function __construct(
+        $inline,
+        $route,
+        array $parameters        = array(),
+        $offset,
+        $limit,
+        $total                   = null,
+        $offsetParameterName     = null,
+        $limitParameterName      = null,
+        $absolute                = false
+    ) {
+        parent::__construct($inline, $route, $parameters, $limit, $total, $limitParameterName, $absolute);
+
+        $this->offset              = $offset;
+        $this->offsetParameterName = $offsetParameterName  ?: 'offset';
+    }
+
+    /**
+     * @return int
+     */
+    public function getOffset()
+    {
+        return $this->offset;
+    }
+
+    /**
+     * @param  null  $offset
+     * @param  null  $limit
+     * @return array
+     */
+    public function getParameters($offset = null, $limit = null)
+    {
+        $parameters = parent::getParameters($limit);
+
+        unset($parameters[$this->offsetParameterName]);
+
+        if (null === $offset) {
+            $offset = $this->getOffset();
+        }
+
+        if ($offset) {
+            $parameters[$this->offsetParameterName] = $offset;
+            $this->moveParameterToEnd($parameters, $this->getLimitParameterName());
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOffsetParameterName()
+    {
+        return $this->offsetParameterName;
+    }
+}

--- a/tests/Hateoas/Tests/Representation/OffsetRepresentationTest.php
+++ b/tests/Hateoas/Tests/Representation/OffsetRepresentationTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace Hateoas\Tests\Representation;
+
+use Hateoas\Representation\CollectionRepresentation;
+use Hateoas\Representation\OffsetRepresentation;
+use Hateoas\Tests\Fixtures\UsersRepresentation;
+
+class OffsetRepresentationTest extends RepresentationTestCase
+{
+    public function testSerialize()
+    {
+        $collection = new OffsetRepresentation(
+            new CollectionRepresentation(
+                array(
+                    'Adrien',
+                    'William',
+                ),
+                'authors',
+                'users'
+            ),
+            '/authors',
+            array(
+                'query' => 'willdurand/Hateoas',
+            ),
+            44,
+            20,
+            95,
+            null,
+            null,
+            false
+        );
+
+        $this
+            ->string($this->hateoas->serialize($collection, 'xml'))
+            ->isEqualTo(
+                <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<collection offset="44" limit="20" total="95">
+  <users rel="authors">
+    <entry><![CDATA[Adrien]]></entry>
+    <entry><![CDATA[William]]></entry>
+  </users>
+  <link rel="self" href="/authors?query=willdurand%2FHateoas&amp;offset=44&amp;limit=20"/>
+  <link rel="first" href="/authors?query=willdurand%2FHateoas&amp;limit=20"/>
+  <link rel="last" href="/authors?query=willdurand%2FHateoas&amp;offset=80&amp;limit=20"/>
+  <link rel="next" href="/authors?query=willdurand%2FHateoas&amp;offset=64&amp;limit=20"/>
+  <link rel="previous" href="/authors?query=willdurand%2FHateoas&amp;offset=24&amp;limit=20"/>
+</collection>
+
+XML
+            )
+            ->string($this->halHateoas->serialize($collection, 'xml'))
+            ->isEqualTo(
+                <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<collection offset="44" limit="20" total="95" href="/authors?query=willdurand%2FHateoas&amp;offset=44&amp;limit=20">
+  <resource rel="authors"><![CDATA[Adrien]]></resource>
+  <resource rel="authors"><![CDATA[William]]></resource>
+  <link rel="first" href="/authors?query=willdurand%2FHateoas&amp;limit=20"/>
+  <link rel="last" href="/authors?query=willdurand%2FHateoas&amp;offset=80&amp;limit=20"/>
+  <link rel="next" href="/authors?query=willdurand%2FHateoas&amp;offset=64&amp;limit=20"/>
+  <link rel="previous" href="/authors?query=willdurand%2FHateoas&amp;offset=24&amp;limit=20"/>
+</collection>
+
+XML
+            )
+            ->string($this->hateoas->serialize(new UsersRepresentation($collection), 'xml'))
+            ->isEqualTo(
+                <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<users offset="44" limit="20" total="95">
+  <users rel="authors">
+    <entry><![CDATA[Adrien]]></entry>
+    <entry><![CDATA[William]]></entry>
+  </users>
+  <link rel="self" href="/authors?query=willdurand%2FHateoas&amp;offset=44&amp;limit=20"/>
+  <link rel="first" href="/authors?query=willdurand%2FHateoas&amp;limit=20"/>
+  <link rel="last" href="/authors?query=willdurand%2FHateoas&amp;offset=80&amp;limit=20"/>
+  <link rel="next" href="/authors?query=willdurand%2FHateoas&amp;offset=64&amp;limit=20"/>
+  <link rel="previous" href="/authors?query=willdurand%2FHateoas&amp;offset=24&amp;limit=20"/>
+</users>
+
+XML
+            )
+            ->string($this->halHateoas->serialize(new UsersRepresentation($collection), 'xml'))
+            ->isEqualTo(
+                <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<users offset="44" limit="20" total="95" href="/authors?query=willdurand%2FHateoas&amp;offset=44&amp;limit=20">
+  <resource rel="authors"><![CDATA[Adrien]]></resource>
+  <resource rel="authors"><![CDATA[William]]></resource>
+  <link rel="first" href="/authors?query=willdurand%2FHateoas&amp;limit=20"/>
+  <link rel="last" href="/authors?query=willdurand%2FHateoas&amp;offset=80&amp;limit=20"/>
+  <link rel="next" href="/authors?query=willdurand%2FHateoas&amp;offset=64&amp;limit=20"/>
+  <link rel="previous" href="/authors?query=willdurand%2FHateoas&amp;offset=24&amp;limit=20"/>
+</users>
+
+XML
+            )
+            ->string($this->halHateoas->serialize($collection, 'json'))
+            ->isEqualTo(
+                '{'
+                    .'"offset":44,'
+                    .'"limit":20,'
+                    .'"total":95,'
+                    .'"_links":{'
+                        .'"self":{'
+                            .'"href":"\/authors?query=willdurand%2FHateoas&offset=44&limit=20"'
+                        .'},'
+                        .'"first":{'
+                            .'"href":"\/authors?query=willdurand%2FHateoas&limit=20"'
+                        .'},'
+                        .'"last":{'
+                            .'"href":"\/authors?query=willdurand%2FHateoas&offset=80&limit=20"'
+                        .'},'
+                        .'"next":{'
+                            .'"href":"\/authors?query=willdurand%2FHateoas&offset=64&limit=20"'
+                        .'},'
+                        .'"previous":{'
+                            .'"href":"\/authors?query=willdurand%2FHateoas&offset=24&limit=20"'
+                        .'}'
+                    .'},'
+                    .'"_embedded":{'
+                        .'"authors":['
+                            .'"Adrien",'
+                            .'"William"'
+                        .']'
+                    .'}'
+                .'}'
+            )
+        ;
+    }
+
+    public function testGenerateAbsoluteURIs()
+    {
+        $collection = new OffsetRepresentation(
+            new CollectionRepresentation(
+                array(
+                    'Adrien',
+                    'William',
+                ),
+                'authors',
+                'users'
+            ),
+            '/authors',
+            array(
+                'query' => 'willdurand/Hateoas',
+            ),
+            44,
+            20,
+            95,
+            null,
+            null,
+            true // force absolute URIs
+        );
+
+        $this
+            ->string($this->hateoas->serialize($collection, 'xml'))
+            ->isEqualTo(
+                <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<collection offset="44" limit="20" total="95">
+  <users rel="authors">
+    <entry><![CDATA[Adrien]]></entry>
+    <entry><![CDATA[William]]></entry>
+  </users>
+  <link rel="self" href="http://example.com/authors?query=willdurand%2FHateoas&amp;offset=44&amp;limit=20"/>
+  <link rel="first" href="http://example.com/authors?query=willdurand%2FHateoas&amp;limit=20"/>
+  <link rel="last" href="http://example.com/authors?query=willdurand%2FHateoas&amp;offset=80&amp;limit=20"/>
+  <link rel="next" href="http://example.com/authors?query=willdurand%2FHateoas&amp;offset=64&amp;limit=20"/>
+  <link rel="previous" href="http://example.com/authors?query=willdurand%2FHateoas&amp;offset=24&amp;limit=20"/>
+</collection>
+
+XML
+            )
+            ->string($this->halHateoas->serialize($collection, 'xml'))
+            ->isEqualTo(
+                <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<collection offset="44" limit="20" total="95" href="http://example.com/authors?query=willdurand%2FHateoas&amp;offset=44&amp;limit=20">
+  <resource rel="authors"><![CDATA[Adrien]]></resource>
+  <resource rel="authors"><![CDATA[William]]></resource>
+  <link rel="first" href="http://example.com/authors?query=willdurand%2FHateoas&amp;limit=20"/>
+  <link rel="last" href="http://example.com/authors?query=willdurand%2FHateoas&amp;offset=80&amp;limit=20"/>
+  <link rel="next" href="http://example.com/authors?query=willdurand%2FHateoas&amp;offset=64&amp;limit=20"/>
+  <link rel="previous" href="http://example.com/authors?query=willdurand%2FHateoas&amp;offset=24&amp;limit=20"/>
+</collection>
+
+XML
+            )
+            ->string($this->halHateoas->serialize($collection, 'json'))
+            ->isEqualTo(
+                '{'
+                    .'"offset":44,'
+                    .'"limit":20,'
+                    .'"total":95,'
+                    .'"_links":{'
+                        .'"self":{'
+                            .'"href":"http:\/\/example.com\/authors?query=willdurand%2FHateoas&offset=44&limit=20"'
+                        .'},'
+                        .'"first":{'
+                            .'"href":"http:\/\/example.com\/authors?query=willdurand%2FHateoas&limit=20"'
+                        .'},'
+                        .'"last":{'
+                            .'"href":"http:\/\/example.com\/authors?query=willdurand%2FHateoas&offset=80&limit=20"'
+                        .'},'
+                        .'"next":{'
+                            .'"href":"http:\/\/example.com\/authors?query=willdurand%2FHateoas&offset=64&limit=20"'
+                        .'},'
+                        .'"previous":{'
+                            .'"href":"http:\/\/example.com\/authors?query=willdurand%2FHateoas&offset=24&limit=20"'
+                        .'}'
+                    .'},'
+                    .'"_embedded":{'
+                        .'"authors":['
+                            .'"Adrien",'
+                            .'"William"'
+                        .']'
+                    .'}'
+                .'}'
+            )
+        ;
+    }
+
+    public function testExclusion()
+    {
+        $inline = new CollectionRepresentation(
+            array(
+                'Adrien',
+                'William',
+            ),
+            'authors',
+            'users'
+        );
+
+        /*
+         * no last entry since `total` is missing
+         * no previous only when offset is 0/null
+         */
+        $collection = new OffsetRepresentation(
+            $inline,
+            '/authors',
+            array(
+                'query' => 'willdurand/Hateoas',
+            ),
+            null,
+            20
+        );
+
+        $this
+            ->string($this->hateoas->serialize($collection, 'xml'))
+            ->isEqualTo(
+                <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<collection limit="20">
+  <users rel="authors">
+    <entry><![CDATA[Adrien]]></entry>
+    <entry><![CDATA[William]]></entry>
+  </users>
+  <link rel="self" href="/authors?query=willdurand%2FHateoas&amp;limit=20"/>
+  <link rel="first" href="/authors?query=willdurand%2FHateoas&amp;limit=20"/>
+  <link rel="next" href="/authors?query=willdurand%2FHateoas&amp;offset=20&amp;limit=20"/>
+</collection>
+
+XML
+            )
+        ;
+
+        /*
+         * no next since on last block
+         */
+        $collection = new OffsetRepresentation(
+            $inline,
+            '/authors',
+            array(
+                'query' => 'willdurand/Hateoas',
+            ),
+            80,
+            20,
+            100
+        );
+
+        $this
+            ->string($this->hateoas->serialize($collection, 'xml'))
+            ->isEqualTo(
+                <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<collection offset="80" limit="20" total="100">
+  <users rel="authors">
+    <entry><![CDATA[Adrien]]></entry>
+    <entry><![CDATA[William]]></entry>
+  </users>
+  <link rel="self" href="/authors?query=willdurand%2FHateoas&amp;offset=80&amp;limit=20"/>
+  <link rel="first" href="/authors?query=willdurand%2FHateoas&amp;limit=20"/>
+  <link rel="last" href="/authors?query=willdurand%2FHateoas&amp;offset=80&amp;limit=20"/>
+  <link rel="previous" href="/authors?query=willdurand%2FHateoas&amp;offset=60&amp;limit=20"/>
+</collection>
+
+XML
+            )
+        ;
+    }
+}


### PR DESCRIPTION
`PaginationRepresentation` is very handy, but is not reusable when the API use a offset/limit/count collection definition.

I've created `OffsetRepresentation` to fill this common use case. There are some similarities to `PaginationRepresentation` but subclassing/abstracting in this case seems overkill to me.

The name can be improved though... `OffsetLimitRepresentation`? `OffsetPaginationRepresentation`?