### PR TITLE
Set a default exclusion configuration to Embedded

### DIFF
--- a/src/Hateoas/Configuration/Relation.php
+++ b/src/Hateoas/Configuration/Relation.php
@@ -42,7 +42,7 @@ class Relation
     public function __construct($name, $href = null, $embedded = null, array $attributes = array(), Exclusion $exclusion = null)
     {
         if (null !== $embedded && !$embedded instanceof Embedded) {
-            $embedded = new Embedded($embedded);
+            $embedded = new Embedded($embedded, null, $exclusion);
         }
 
         if (null === !$href && null === $embedded) {


### PR DESCRIPTION
This is a bug fix.

Right now default `Embedded` won't have any exclusion configuration, and result in all default `Embedded` object only work in Default group.

This patch will apply exclusion configuration to the `Embedded` created by `Relation`, and fix the problem.