### PR TITLE
travis: PHP 5.6 and 7.0 nightly added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,19 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
+    - 7.0
     - hhvm
 
 matrix:
+    fast_finish: true
     allow_failures:
+        - php: 7.0
         - php: hhvm
 
 before_script:
     - composer self-update
-    - composer install --dev --prefer-dist --no-interaction
+    - composer install --prefer-dist --no-interaction
 
-script: phpunit --coverage-text
+script:
+    - phpunit --coverage-text


### PR DESCRIPTION
- `--dev` is by default and deprecated