### PR TITLE
Assign class, name and type properties on RelationPropertyMetadata

### DIFF
--- a/src/Hateoas/Serializer/ExclusionManager.php
+++ b/src/Hateoas/Serializer/ExclusionManager.php
@@ -45,18 +45,18 @@ class ExclusionManager
             return $this->shouldSkipRelation($object, $relation, $context);
         }
 
-        return $this->shouldSkip($object, $relation->getEmbedded()->getExclusion(), $context);
+        return $this->shouldSkip($object, $relation, $relation->getEmbedded()->getExclusion(), $context);
     }
 
     private function shouldSkipRelation($object, Relation $relation, SerializationContext $context)
     {
-        return $this->shouldSkip($object, $relation->getExclusion(), $context);
+        return $this->shouldSkip($object, $relation, $relation->getExclusion(), $context);
     }
 
-    private function shouldSkip($object, Exclusion $exclusion = null, SerializationContext $context)
+    private function shouldSkip($object, Relation $relation, Exclusion $exclusion = null, SerializationContext $context)
     {
         if ($context->getExclusionStrategy()) {
-            $propertyMetadata = new RelationPropertyMetadata($exclusion);
+            $propertyMetadata = new RelationPropertyMetadata($exclusion, $relation);
 
             if ($context->getExclusionStrategy()->shouldSkipProperty($propertyMetadata, $context)) {
                 return true;

--- a/src/Hateoas/Serializer/Metadata/RelationPropertyMetadata.php
+++ b/src/Hateoas/Serializer/Metadata/RelationPropertyMetadata.php
@@ -3,15 +3,29 @@
 namespace Hateoas\Serializer\Metadata;
 
 use Hateoas\Configuration\Exclusion;
+use Hateoas\Configuration\Relation;
 use JMS\Serializer\Metadata\VirtualPropertyMetadata;
+use JMS\Serializer\TypeParser;
 
 /**
  * @author Adrien Brault <adrien.brault@gmail.com>
  */
 class RelationPropertyMetadata extends VirtualPropertyMetadata
 {
-    public function __construct(Exclusion $exclusion = null)
+    public function __construct(Exclusion $exclusion = null, Relation $relation = null)
     {
+        if (null !== $relation) {
+            $this->name = $relation->getName();
+            $this->class = get_class($relation);
+
+            $typeParser = new TypeParser();
+            if (null !== $relation->getEmbedded()) {
+                $this->type = $typeParser->parse('Hateoas\Model\Embedded');
+            } elseif (null !== $relation->getHref()) {
+                $this->type = $typeParser->parse('Hateoas\Model\Link');
+            }
+        }
+
         if (null === $exclusion) {
             return;
         }

--- a/tests/Hateoas/Tests/Serializer/Metadata/RelationPropertyMetadataTest.php
+++ b/tests/Hateoas/Tests/Serializer/Metadata/RelationPropertyMetadataTest.php
@@ -2,7 +2,10 @@
 
 namespace Hateoas\Tests\Serializer\Metadata;
 
+use Hateoas\Configuration\Embedded;
 use Hateoas\Configuration\Exclusion;
+use Hateoas\Configuration\Relation;
+use Hateoas\Configuration\Route;
 use Hateoas\Serializer\Metadata\RelationPropertyMetadata;
 use Hateoas\Tests\TestCase;
 
@@ -42,6 +45,41 @@ class RelationPropertyMetadataTest extends TestCase
                 ->isEqualTo(2.2)
             ->variable($propertyMetadata->maxDepth)
                 ->isEqualTo(42)
+        ;
+    }
+
+    public function testWithEmbeddedRelation()
+    {
+        $propertyMetadata = new RelationPropertyMetadata(null, new Relation(
+            'foo',
+            null,
+            new Embedded('bar', array('name' => 'John'))
+        ));
+
+        $this
+            ->variable($propertyMetadata->name)
+                ->isEqualTo('foo')
+            ->variable($propertyMetadata->class)
+                ->isEqualTo('Hateoas\Configuration\Relation')
+            ->variable($propertyMetadata->type)
+                ->isEqualTo(array('name' => 'Hateoas\Model\Embedded', 'params' => array()))
+        ;
+    }
+
+    public function testWithLinkRelation()
+    {
+        $propertyMetadata = new RelationPropertyMetadata(null, new Relation(
+            'foo',
+            new Route('/route', array('foo' => 'bar'))
+        ));
+
+        $this
+            ->variable($propertyMetadata->name)
+                ->isEqualTo('foo')
+            ->variable($propertyMetadata->class)
+                ->isEqualTo('Hateoas\Configuration\Relation')
+            ->variable($propertyMetadata->type)
+                ->isEqualTo(array('name' => 'Hateoas\Model\Link', 'params' => array()))
         ;
     }
 }


### PR DESCRIPTION
#210 

For now, there is no way to identify a relation in https://github.com/willdurand/Hateoas/blob/master/src/Hateoas/Serializer/Metadata/RelationPropertyMetadata.php.

This PR assign the `class`, `name` and `type` properties in addition to `groups`, `sinceVersion`, `untilVersion` and `maxDepth` exclusion properties.