### PR TITLE
Evaluate ExcludeIf after JMS exclusion strategy

### DIFF
--- a/src/Hateoas/Serializer/ExclusionManager.php
+++ b/src/Hateoas/Serializer/ExclusionManager.php
@@ -55,6 +55,14 @@ class ExclusionManager
 
     private function shouldSkip($object, Exclusion $exclusion = null, SerializationContext $context)
     {
+        if ($context->getExclusionStrategy()) {
+            $propertyMetadata = new RelationPropertyMetadata($exclusion);
+
+            if ($context->getExclusionStrategy()->shouldSkipProperty($propertyMetadata, $context)) {
+                return true;
+            }
+        }
+
         if (null !== $exclusion
             && null !== $exclusion->getExcludeIf()
             && $this->expressionEvaluator->evaluate($exclusion->getExcludeIf(), $object)
@@ -62,12 +70,6 @@ class ExclusionManager
             return true;
         }
 
-        if (!$context->getExclusionStrategy()) {
-            return false;
-        }
-
-        $propertyMetadata = new RelationPropertyMetadata($exclusion);
-
-        return $context->getExclusionStrategy()->shouldSkipProperty($propertyMetadata, $context);
+        return false;
     }
 }


### PR DESCRIPTION
This change enhance the perf of the ExclusionManager.

Most of all JMS ExclusionStrategyInterface relies on counter, isset and other basic language functionalities, while the evaluator allows to instantiate service or triggers voter through isGranted.

Evaluating this code whereas simple checks like groups or version already exclude adds a significant overhead.

This change inverts the order of the execution.