### PR TITLE
Add ability to exclude a link if a serialization group IS present

### DIFF
--- a/src/Hateoas/Configuration/Annotation/Exclusion.php
+++ b/src/Hateoas/Configuration/Annotation/Exclusion.php
@@ -38,4 +38,9 @@ final class Exclusion
      * @var string
      */
     public $excludeIf = null;
+
+    /**
+     * @var array
+     */
+    public $notGroups = null;
 }

--- a/src/Hateoas/Configuration/Exclusion.php
+++ b/src/Hateoas/Configuration/Exclusion.php
@@ -32,18 +32,25 @@ class Exclusion
      */
     private $excludeIf;
 
+    /**
+     * @var null|array
+     */
+    private $notGroups;
+
     public function __construct(
         array $groups = null,
         $sinceVersion = null,
         $untilVersion = null,
         $maxDepth = null,
-        $excludeIf = null
+        $excludeIf = null,
+        array $notGroups = null
     ) {
         $this->groups = $groups;
         $this->sinceVersion = null !== $sinceVersion ? (float) $sinceVersion : null;
         $this->untilVersion = null !== $untilVersion ? (float) $untilVersion : null;
         $this->maxDepth = null !== $maxDepth ? (int) $maxDepth : null;
         $this->excludeIf = $excludeIf;
+        $this->notGroups = $notGroups;
     }
 
     /**
@@ -84,5 +91,13 @@ class Exclusion
     public function getExcludeIf()
     {
         return $this->excludeIf;
+    }
+
+    /**
+     * @return null|array
+     */
+    public function getNotGroups()
+    {
+        return $this->notGroups;
     }
 }

--- a/src/Hateoas/Configuration/Metadata/Driver/AnnotationDriver.php
+++ b/src/Hateoas/Configuration/Metadata/Driver/AnnotationDriver.php
@@ -72,7 +72,8 @@ class AnnotationDriver implements DriverInterface
             $exclusion->sinceVersion,
             $exclusion->untilVersion,
             $exclusion->maxDepth,
-            $exclusion->excludeIf
+            $exclusion->excludeIf,
+            $exclusion->notGroups
         );
     }
 

--- a/src/Hateoas/Serializer/ExclusionManager.php
+++ b/src/Hateoas/Serializer/ExclusionManager.php
@@ -70,6 +70,17 @@ class ExclusionManager
             return true;
         }
 
+        if (null !== $exclusion) {
+            $exclusionGroups = $exclusion->getNotGroups();
+            $contextGroups = $context->attributes->get('groups')->get();
+            if (
+                is_array($exclusionGroups) &&
+                0 < count(array_intersect($contextGroups, $exclusionGroups))
+            ) {
+                return true;
+            }
+        }
+
         return false;
     }
 }

--- a/src/Hateoas/Serializer/Metadata/RelationPropertyMetadata.php
+++ b/src/Hateoas/Serializer/Metadata/RelationPropertyMetadata.php
@@ -20,5 +20,6 @@ class RelationPropertyMetadata extends VirtualPropertyMetadata
         $this->sinceVersion = $exclusion->getSinceVersion();
         $this->untilVersion = $exclusion->getUntilVersion();
         $this->maxDepth = $exclusion->getMaxDepth();
+        $this->notGroups = $exclusion->getNotGroups();
     }
 }


### PR DESCRIPTION
Hi,

I'm looking to have the ability to include one Hateoas link on my entity when a group is present, and a different Hateoas link when that group is NOT present.

With the current feature set, I couldn't find a way to do the inverse of what the current `@Hateoas\Exclusion(groups="groupNameHere")` annotation did, and so I created a new exclusion property `notGroups`.

Is there another way to do this without this pull request?  If not, and you'd be willing to accept this, let me know and I'll put the additional work to update the documentation and test coverage (as well as any other changes you may have).

Thanks for making such a great library!
-Matt
