### PR TITLE
Don't use hardcoded values for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate

### DIFF
--- a/src/Hateoas/Factory/LinkFactory.php
+++ b/src/Hateoas/Factory/LinkFactory.php
@@ -7,6 +7,7 @@ use Hateoas\Configuration\Route;
 use Hateoas\Expression\ExpressionEvaluator;
 use Hateoas\Model\Link;
 use Hateoas\UrlGenerator\UrlGeneratorRegistry;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface as SymfonyUrlGeneratorInterface;
 
 /**
  * @author Adrien Brault <adrien.brault@gmail.com>
@@ -54,7 +55,10 @@ class LinkFactory
                 ? $this->expressionEvaluator->evaluateArray($href->getParameters(), $object)
                 : $this->expressionEvaluator->evaluate($href->getParameters(), $object)
             ;
-            $isAbsolute = $this->expressionEvaluator->evaluate($href->isAbsolute(), $object);
+            $isAbsolute = $this->expressionEvaluator->evaluate($href->isAbsolute(), $object)
+                ? SymfonyUrlGeneratorInterface::ABSOLUTE_PATH
+                : SymfonyUrlGeneratorInterface::ABSOLUTE_URL
+            ;
 
             if (!is_array($parameters)) {
                 throw new \RuntimeException(


### PR DESCRIPTION
The hardcoded value you are using for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate method is deprecated since version 2.8 and will not be supported anymore in 3.0. Use the constants defined in the UrlGeneratorInterface instead.