### PR TITLE
Use correct SymfonyUrlGeneratorInterface constants for absolute path

### DIFF
--- a/src/Hateoas/Factory/LinkFactory.php
+++ b/src/Hateoas/Factory/LinkFactory.php
@@ -56,8 +56,8 @@ class LinkFactory
                 : $this->expressionEvaluator->evaluate($href->getParameters(), $object)
             ;
             $isAbsolute = $this->expressionEvaluator->evaluate($href->isAbsolute(), $object)
-                ? SymfonyUrlGeneratorInterface::ABSOLUTE_PATH
-                : SymfonyUrlGeneratorInterface::ABSOLUTE_URL
+                ? SymfonyUrlGeneratorInterface::ABSOLUTE_URL
+                : SymfonyUrlGeneratorInterface::ABSOLUTE_PATH
             ;
 
             if (!is_array($parameters)) {


### PR DESCRIPTION
When $this->expressionEvaluator->evaluate($href->isAbsolute(), $object) returns true then we should generate absolute (with host) path - for this we should use SymfonyUrlGeneratorInterface::ABSOLUTE_URL, when we want to get relative ulr (but with absolute path) we should use SymfonyUrlGeneratorInterface::ABSOLUTE_PATH

Sorry for wrong PR - this one pass all my tests and keeps library backward compatible. 