### PR TITLE
Use UrlGeneratorInterface constants for UrlGenerator::generate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,13 @@ matrix:
     fast_finish: true
     allow_failures:
         - php: hhvm
+env:
+  - PREFER_LOWEST="--prefer-lowest"
+  - PREFER_LOWEST=""
 
 before_script:
     - composer self-update
-    - composer install --prefer-dist --no-interaction
+    - composer update --prefer-dist --no-interaction $PREFER_LOWEST
 
 script:
     - ./bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,14 @@
         "doctrine/annotations": "~1.0",
         "jms/metadata": "~1.1",
         "jms/serializer": "~1.0",
-        "symfony/expression-language": "~2.4 || ~3.0"
+        "symfony/expression-language": "~2.4 || ~3.0",
+        "phpoption/phpoption": ">=1.1.0,<2.0-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
-        "symfony/yaml": "~2.0 || ~3.0",
-        "symfony/routing": "~2.0 || ~3.0",
-        "symfony/dependency-injection": "~2.0 || ~3.0",
+        "symfony/yaml": "~2.4 || ~3.0",
+        "symfony/routing": "~2.4 || ~3.0",
+        "symfony/dependency-injection": "~2.4 || ~3.0",
         "pagerfanta/pagerfanta": "~1.0",
         "twig/twig": "~1.12"
     },

--- a/src/Hateoas/UrlGenerator/SymfonyUrlGenerator.php
+++ b/src/Hateoas/UrlGenerator/SymfonyUrlGenerator.php
@@ -24,6 +24,14 @@ class SymfonyUrlGenerator implements UrlGeneratorInterface
      */
     public function generate($name, array $parameters, $absolute = false)
     {
+        // If is it at least Symfony 2.8 and $absolute is passed as boolean
+        if (SymfonyUrlGeneratorInterface::ABSOLUTE_PATH === 1 && is_bool($absolute)) {
+            $absolute = $absolute
+                ? SymfonyUrlGeneratorInterface::ABSOLUTE_URL
+                : SymfonyUrlGeneratorInterface::ABSOLUTE_PATH
+            ;
+        }
+
         return $this->urlGenerator->generate($name, $parameters, $absolute);
     }
 }

--- a/tests/Hateoas/Tests/UrlGenerator/SymfonyUrlGeneratorTest.php
+++ b/tests/Hateoas/Tests/UrlGenerator/SymfonyUrlGeneratorTest.php
@@ -14,6 +14,10 @@ class SymfonyUrlGeneratorTest extends TestCase
         $absolute       = true;
         $expectedResult = '/users/42';
 
+        if (\Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_PATH === 1) {
+            $absolute = \Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL;
+        }
+
         $symfonyUrlGeneratorProphecy = $this->prophesize('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
         $symfonyUrlGeneratorProphecy
             ->generate($name, $parameters, $absolute)


### PR DESCRIPTION
Don't use hardcoded values for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate

for full absolute path use Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL 
for relative path (with absolute url) use Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_PATH