### PR TITLE
Avoid serializing the same object twice

### DIFF
--- a/src/Hateoas/Serializer/EventSubscriber/JsonEventSubscriber.php
+++ b/src/Hateoas/Serializer/EventSubscriber/JsonEventSubscriber.php
@@ -80,6 +80,8 @@ class JsonEventSubscriber implements EventSubscriberInterface
         $object  = $event->getObject();
         $context = $event->getContext();
 
+        $context->startVisiting($object);
+
         $embeddeds = $this->embeddedsFactory->create($object, $context);
         $links     = $this->linksFactory->create($object, $context);
 
@@ -93,5 +95,7 @@ class JsonEventSubscriber implements EventSubscriberInterface
         if (count($embeddeds) > 0) {
             $this->jsonSerializer->serializeEmbeddeds($embeddeds, $event->getVisitor(), $context);
         }
+
+        $context->stopVisiting($object);
     }
 }

--- a/src/Hateoas/Serializer/EventSubscriber/XmlEventSubscriber.php
+++ b/src/Hateoas/Serializer/EventSubscriber/XmlEventSubscriber.php
@@ -57,9 +57,13 @@ class XmlEventSubscriber implements EventSubscriberInterface
 
     public function onPostSerialize(ObjectEvent $event)
     {
-        $context   = $event->getContext();
-        $embeddeds = $this->embeddedsFactory->create($event->getObject(), $event->getContext());
-        $links     = $this->linksFactory->create($event->getObject(), $event->getContext());
+        $object  = $event->getObject();
+        $context = $event->getContext();
+
+        $context->startVisiting($object);
+        
+        $embeddeds = $this->embeddedsFactory->create($object, $context);
+        $links     = $this->linksFactory->create($object, $context);
 
         if (count($links) > 0) {
             $this->xmlSerializer->serializeLinks($links, $event->getVisitor(), $context);
@@ -68,5 +72,7 @@ class XmlEventSubscriber implements EventSubscriberInterface
         if (count($embeddeds) > 0) {
             $this->xmlSerializer->serializeEmbeddeds($embeddeds, $event->getVisitor(), $context);
         }
+
+        $context->stopVisiting($object);
     }
 }

--- a/tests/Hateoas/Tests/Fixtures/CircularReference1.php
+++ b/tests/Hateoas/Tests/Fixtures/CircularReference1.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Hateoas\Tests\Fixtures;
+
+use Hateoas\Configuration\Annotation as Hateoas;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\ExclusionPolicy("all")
+ *
+ * @Hateoas\Relation("reference2", embedded="expr(object.getReference2())")
+ */
+class CircularReference1
+{
+    /**
+     * @Serializer\Expose
+     */
+    private $name = 'reference1';
+
+    private $reference2;
+
+    public function setReference2($reference2)
+    {
+        $this->reference2 = $reference2;
+    }
+
+    public function getReference2()
+    {
+        return $this->reference2;
+    }
+}

--- a/tests/Hateoas/Tests/Fixtures/CircularReference2.php
+++ b/tests/Hateoas/Tests/Fixtures/CircularReference2.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Hateoas\Tests\Fixtures;
+
+use Hateoas\Configuration\Annotation as Hateoas;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\ExclusionPolicy("all")
+ *
+ * @Hateoas\Relation("reference1", embedded="expr(object.getReference1())")
+ */
+class CircularReference2
+{
+    /**
+     * @Serializer\Expose
+     */
+    private $name = 'reference2';
+
+    private $reference1;
+
+    public function setReference1($reference1)
+    {
+        $this->reference1 = $reference1;
+    }
+
+    public function getReference1()
+    {
+        return $this->reference1;
+    }
+}

--- a/tests/Hateoas/Tests/HateoasBuilderTest.php
+++ b/tests/Hateoas/Tests/HateoasBuilderTest.php
@@ -3,6 +3,8 @@
 namespace Hateoas\Tests;
 
 use Hateoas\HateoasBuilder;
+use Hateoas\Tests\Fixtures\CircularReference1;
+use Hateoas\Tests\Fixtures\CircularReference2;
 use Hateoas\UrlGenerator\CallableUrlGenerator;
 use JMS\Serializer\SerializationContext;
 use Hateoas\Tests\Fixtures\AdrienBrault;
@@ -83,6 +85,47 @@ XML
 XML
             ,
             $hateoas->serialize(new WithAlternativeRouter(), 'xml')
+        );
+    }
+
+    public function testCyclicalReferences()
+    {
+        $hateoas = HateoasBuilder::create()->build();
+
+        $reference1 = new CircularReference1();
+        $reference2 = new CircularReference2();
+        $reference1->setReference2($reference2);
+        $reference2->setReference1($reference1);
+
+        $this->assertSame(
+            <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <name><![CDATA[reference1]]></name>
+  <entry rel="reference2">
+    <name><![CDATA[reference2]]></name>
+    <entry rel="reference1"/>
+  </entry>
+</result>
+
+XML
+            ,
+            $hateoas->serialize($reference1, 'xml')
+        );
+
+        $this->assertSame(
+            '{'
+                .'"name":"reference1",'
+                .'"_embedded":{'
+                    .'"reference2":{'
+                        .'"name":"reference2",'
+                        .'"_embedded":{'
+                            .'"reference1":null'
+                        .'}'
+                    .'}'
+                .'}'
+            .'}',
+            $hateoas->serialize($reference1, 'json')
         );
     }
 }


### PR DESCRIPTION
The serializer knows how to take care of circular references: https://github.com/schmittjoh/serializer/blob/fe13a1f993ea3456e195b7820692f2eb2b6bbb48/src/JMS/Serializer/GraphNavigator.php#L141-L144

However, because we serialize embeds during the "post serialize" event, the visitingStack is empty: https://github.com/schmittjoh/serializer/blob/fe13a1f993ea3456e195b7820692f2eb2b6bbb48/src/JMS/Serializer/GraphNavigator.php#L292-L316

This patch makes sure that embedded data is serialized the same way it would if it was serialized as a property.