### PR TITLE
Allow higher symfony/yaml version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "symfony/property-access": "~2.2",
         "jms/serializer": ">=0.12,<0.13-dev",
-        "symfony/yaml": "~2.0"
+        "symfony/yaml": "~2.0 || ~3.0"
     },
     "require-dev": {
         "symfony/routing": "~2.0",


### PR DESCRIPTION
On one project I'm still stuck with the 1.0 branch but I need a higher version of `symfony/yaml`, this allows it and the test suite is green :)