### PR TITLE
JMS serializer in 1.7.0 will revert a BC break introduced in 1.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/common": "~2.0",
         "doctrine/annotations": "~1.0",
         "jms/metadata": "~1.1",
-        "jms/serializer": "^1.6.1",
+        "jms/serializer": "^1.7",
         "symfony/expression-language": "~2.4 || ~3.0",
         "phpoption/phpoption": ">=1.1.0,<2.0-dev"
     },

--- a/tests/Hateoas/Tests/Fixtures/Gh236Bar.php
+++ b/tests/Hateoas/Tests/Fixtures/Gh236Bar.php
@@ -13,6 +13,7 @@ class Gh236Bar
 
     /**
      * @Serializer\Expose()
+     * @Serializer\SkipWhenEmpty()
      */
     public $inner;
 }


### PR DESCRIPTION
JMS serializer in 1.7.0 will revert a BC break introduced in 1.6.1.

https://github.com/schmittjoh/serializer/pull/744 (that was fundamental for https://github.com/willdurand/Hateoas/pull/246) will be replaced by a option introduced  with https://github.com/schmittjoh/serializer/pull/757  and will be released with the serializer 1.7.0

To have https://github.com/willdurand/Hateoas/pull/246 working correctly some changes are required 

1.7.0 is not yet released (planned in 10 days)