### PR TITLE
Run tests into travis containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 cache:
   directories:
     - $COMPOSER_CACHE_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   - SYMFONY_VERSION=2.7.*
   - SYMFONY_VERSION=2.8.*
   - SYMFONY_VERSION=3.0.*
+  - SYMFONY_VERSION=3.2.*
 
 before_install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 cache:
   directories:
-    - $COMPOSER_CACHE_DIR
+    - $HOME/.composer/cache
 
 php:
   - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
-
-sudo: false
+sudo: required
+dist: trusty
+group: edge
 
 cache:
   directories:
@@ -11,11 +12,13 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - hhvm-3.9
+  - hhvm-3.12
+  - hhvm-3.15
+  - hhvm-3.18
 
-allow_failures:
-  - php: hhvm
-
+matrix:
+    fast_finish: true
 env:
   - SYMFONY_VERSION=2.4.*
   - SYMFONY_VERSION=2.5.*
@@ -23,11 +26,6 @@ env:
   - SYMFONY_VERSION=2.7.*
   - SYMFONY_VERSION=2.8.*
   - SYMFONY_VERSION=3.0.*
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - php: hhvm
 
 before_install:
   - composer self-update


### PR DESCRIPTION
For faster builds

See https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments

> Container-based (Fast boot time environment in which sudo commands are not available)

in this project "13 min 59 sec" (current) vs "9 min 55 sec" (proposed)