### PR TITLE
Fix `HateoasBuilder::createDir` throws exception in race condition

### DIFF
--- a/src/Hateoas/HateoasBuilder.php
+++ b/src/Hateoas/HateoasBuilder.php
@@ -505,7 +505,7 @@ class HateoasBuilder
             return;
         }
 
-        if (false === @mkdir($dir, 0777, true)) {
+        if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
             throw new \RuntimeException(sprintf('Could not create directory "%s".', $dir));
         }
     }


### PR DESCRIPTION
This fixes a rare race condition that can be observed in rare cases in heavy load right after new deployment, that when hit the `createDir` throws an exception. 
Under heavy load other server request to the same code may have been able to create the directory right in the microseconds gap between checking if `is_dir($dir)` and the execution of `@mkdir($dir, 0777, true)`.
