### PR TITLE
Fixed broken header rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,7 +850,7 @@ that rather than being links, the values are resource objects.
 }
 ```
 
-#### The XmlSerializer
+#### The XmlSerializer
 
 The `XmlSerializer` allows you to generate [Atom
 Links](http://tools.ietf.org/search/rfc4287#section-4.2.7) into your XML


### PR DESCRIPTION
Not sure why but the "The XmlSerializer" header was rendered as plain text (maybe some hidden character), after rewriting it became a proper header again.