### PR TITLE
Do not serialise a null embedded property.

### DIFF
--- a/src/Hateoas/Serializer/JsonHalSerializer.php
+++ b/src/Hateoas/Serializer/JsonHalSerializer.php
@@ -48,7 +48,7 @@ class JsonHalSerializer implements JsonSerializerInterface
 
             $content = $context->accept($embedded->getData());
 
-            if(true !== $context->shouldSerializeNull() && !$content) {
+            if (true !== $context->shouldSerializeNull() && null === $content) {
                 $context->popPropertyMetadata();
                 continue;
             }
@@ -69,7 +69,7 @@ class JsonHalSerializer implements JsonSerializerInterface
             $context->popPropertyMetadata();
         }
 
-        if(empty($serializedEmbeddeds)){
+        if(count($serializedEmbeddeds) === 0){
             return;
         }
 

--- a/tests/Hateoas/Tests/HateoasBuilderTest.php
+++ b/tests/Hateoas/Tests/HateoasBuilderTest.php
@@ -118,14 +118,52 @@ XML
                 .'"name":"reference1",'
                 .'"_embedded":{'
                     .'"reference2":{'
-                        .'"name":"reference2",'
-                        .'"_embedded":{'
-                            .'"reference1":null'
-                        .'}'
+                        .'"name":"reference2",'.
+                        '"_embedded":{'.
+                            '"reference1":null'.
+                        '}'
                     .'}'
                 .'}'
             .'}',
-            $hateoas->serialize($reference1, 'json')
+            $hateoas->serialize($reference1, 'json', SerializationContext::create()->setSerializeNull(true))
+        );
+    }
+
+    public function testShouldNotSerialiseNull()
+    {
+        $hateoas = HateoasBuilder::create()->build();
+
+        $reference1 = new CircularReference1();
+        $reference2 = new CircularReference2();
+        $reference1->setReference2($reference2);
+        $reference2->setReference1($reference1);
+
+        $this->assertSame(
+            <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <name><![CDATA[reference1]]></name>
+  <entry rel="reference2">
+    <name><![CDATA[reference2]]></name>
+    <entry rel="reference1"/>
+  </entry>
+</result>
+
+XML
+            ,
+            $hateoas->serialize($reference1, 'xml')
+        );
+
+        $this->assertSame(
+            '{'
+                .'"name":"reference1",'
+                .'"_embedded":{'
+                    .'"reference2":{'
+                        .'"name":"reference2"'
+                    .'}'
+                .'}'
+            .'}',
+            $hateoas->serialize($reference1, 'json', SerializationContext::create()->setSerializeNull(false))
         );
     }
 }

--- a/tests/Hateoas/Tests/HateoasBuilderTest.php
+++ b/tests/Hateoas/Tests/HateoasBuilderTest.php
@@ -129,7 +129,7 @@ XML
         );
     }
 
-    public function testShouldNotSerialiseNull()
+    public function testCyclicalReferencesWithoutNull()
     {
         $hateoas = HateoasBuilder::create()->build();
 

--- a/tests/Hateoas/Tests/Serializer/JsonHalSerializerTest.php
+++ b/tests/Hateoas/Tests/Serializer/JsonHalSerializerTest.php
@@ -82,6 +82,7 @@ class JsonHalSerializerTest extends TestCase
         }
         $contextProphecy->pushPropertyMetadata(Argument::type('Hateoas\Serializer\Metadata\RelationPropertyMetadata'))->shouldBeCalled();
         $contextProphecy->popPropertyMetadata()->shouldBeCalled();
+        $contextProphecy->shouldSerializeNull()->willReturn(false);
 
         $embeddeds = array(
             new Embedded('friend', array('name' => 'John'), new RelationPropertyMetadata()),


### PR DESCRIPTION
Right now when an embedded value is null HATEOAS serialises it anyway.

`
"_embedded" : {
"reference1" : null
}
`

Thinking it's a wrong design I decided to fix it. Like that a null
embedded value is not serialised anymore.  Giving that kind of response:
`
"_embedded" : {}
`

Let me know if I made a mistake. Maybe we should take into account  the shouldSerialiseNull present in the context of JMS.


Kind regards
L.  