### PR TITLE
Fix #281 RelationProvider 1st argument constructor must be string ...

### DIFF
--- a/src/Configuration/Metadata/Driver/XmlDriver.php
+++ b/src/Configuration/Metadata/Driver/XmlDriver.php
@@ -72,7 +72,7 @@ class XmlDriver extends AbstractFileDriver
             $providers = preg_split('/\s*,\s*/', (string) $exists[0]->attributes(self::NAMESPACE_URI)->providers);
 
             foreach ($providers as $relationProvider) {
-                $relations = $this->relationProvider->getRelations(new RelationProvider($this->checkExpression($relationProvider)), $class->getName());
+                $relations = $this->relationProvider->getRelations(new RelationProvider((string) $this->checkExpression($relationProvider)), $class->getName());
                 foreach ($relations as $relation) {
                     $classMetadata->addRelation($relation);
                 }


### PR DESCRIPTION
…object given

Fix #281 
> TypeError: Argument 1 passed to Hateoas\Configuration\RelationProvider::__construct() must be of the type string, object given, called in /srv/http/vendor/willdurand/hateoas/src/Configuration/Metadata/Driver/XmlDriver.php on line 75

Type casting, force the return of checkExpression in string.