### PR TITLE
make sure relation link  is object

### DIFF
--- a/src/Factory/EmbeddedsFactory.php
+++ b/src/Factory/EmbeddedsFactory.php
@@ -63,7 +63,7 @@ class EmbeddedsFactory
 
                 $propertyMetadata = new RelationPropertyMetadata($relation->getEmbedded()->getExclusion(), $relation);
 
-                $embeddeds[] = new Embedded($rel, $data, $propertyMetadata, $xmlElementName, $relation->getEmbedded()->getType());
+                $embeddeds[$rel] = new Embedded($rel, $data, $propertyMetadata, $xmlElementName, $relation->getEmbedded()->getType());
             }
         }
         return $embeddeds;

--- a/src/Factory/LinksFactory.php
+++ b/src/Factory/LinksFactory.php
@@ -48,7 +48,7 @@ class LinksFactory
                     continue;
                 }
 
-                $links[] = $this->linkFactory->createLink($object, $relation, $context);
+                $links[$relation->getName()] = $this->linkFactory->createLink($object, $relation, $context);
             }
         }
 


### PR DESCRIPTION
this should not break anything, but guarantee that  relation link is object.
for example , the following configuration provides two two relations, they have the same relation name,  which will make the `view relation` is array. this is meaningless.
```
App\Entity\Example:
    properties:
	id:
	        type: integer
	        xml_attribute: true
   relations:
        -   rel: view
            href:
                route: api_example_view
                parameters:
                    id: expr(object.getId())
    relation_provider: 'a_provider_also_have_a_relation_named_view'
```
```
{
    "id": 2,
    "_links": {
        "view": [
            {
                "href": "/api/admin/block_containers/2"
            },
            {
                "href": "/api/admin/block_containers/2"
            }
        ]
    }
}
```
it supposed to be  like this.

```
            {
                "id": 2,
                "_links": {
                    "view": {
                        "href": "/api/admin/block_containers/2"
                    }
                }
            }
```