### PR TITLE
Expressions in attributes are not supported when using YAML.

### DIFF
--- a/src/Configuration/Metadata/Driver/YamlDriver.php
+++ b/src/Configuration/Metadata/Driver/YamlDriver.php
@@ -67,7 +67,7 @@ class YamlDriver extends AbstractFileDriver
                     $relation['rel'],
                     $this->createHref($relation),
                     $this->createEmbedded($relation),
-                    $relation['attributes'] ?? [],
+                    isset($relation['attributes']) ? $this->checkExpressionArray($relation['attributes']): [],
                     $this->createExclusion($relation)
                 ));
             }

--- a/tests/Hateoas/Tests/Configuration/Metadata/Driver/AbstractDriverTest.php
+++ b/tests/Hateoas/Tests/Configuration/Metadata/Driver/AbstractDriverTest.php
@@ -134,10 +134,14 @@ abstract class AbstractDriverTest extends TestCase
         $this->assertSame(43, $relation->getEmbedded()->getExclusion()->getMaxDepth());
         $this->assertSame('bar', $relation->getEmbedded()->getExclusion()->getExcludeIf());
 
+        $relation = $relations[$i++];
+        $this->assertSame('attribute_with_expression', $relation->getName());
+        $this->assertEquals(['baz' => $exp->parse('object.getId()', ['object'])], $relation->getAttributes());
+
         /** @var RelationProvider[] $relations */
         $relations = $classMetadata->getRelations();
         $this->assertInternalType('array', $relations);
-        $this->assertCount(7, $relations);
+        $this->assertCount(8, $relations);
 
 //        $relation = current($relations);
 //        $this->assertSame('getRelations', $relation->getName());

--- a/tests/Hateoas/Tests/Fixtures/User.php
+++ b/tests/Hateoas/Tests/Fixtures/User.php
@@ -36,6 +36,7 @@ use Hateoas\Configuration\Annotation as Hateoas;
  *          )
  *      )
  * )
+ * @Hateoas\Relation("attribute_with_expression", href = "baz", attributes = {"baz" = "expr(object.getId())"})
  * @Hateoas\RelationProvider("Hateoas\Tests\Fixtures\User::getRelations")
  */
 class User

--- a/tests/Hateoas/Tests/Fixtures/config/User.xml
+++ b/tests/Hateoas/Tests/Fixtures/config/User.xml
@@ -48,5 +48,10 @@
             </h:embedded>
             <h:exclusion groups="group1, group2" since-version="1" until-version="2.2" max-depth="42" exclude-if="foo"/>
         </h:relation>
+
+        <h:relation rel="attribute_with_expression">
+            <h:href uri="baz"/>
+            <h:attribute name="baz" value="expr(object.getId())"/>
+        </h:relation>
     </class>
 </serializer>

--- a/tests/Hateoas/Tests/Fixtures/config/User.yml
+++ b/tests/Hateoas/Tests/Fixtures/config/User.yml
@@ -50,4 +50,10 @@ Hateoas\Tests\Fixtures\User:
                     until_version: 2.3
                     max_depth: 43
                     exclude_if: bar
+        -
+            rel: attribute_with_expression
+            href: baz
+            attributes:
+                baz: expr(object.getId())
+
     relation_providers: [ Hateoas\Tests\Fixtures\User::getRelations ]


### PR DESCRIPTION
Looks like this was not supported and not being evaluated.

```yaml
   rel: foo
   href: bar
   attributes:
      baz: expr(object.getId())
```

Appears that all the other drivers (XML, annotation) respected expressions in attributes, except YAML driver.

This PR fixes that.