### PR TITLE
Address deprecations from persistence lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "phpunit/phpunit": "^7",
         "doctrine/coding-standard": "^5.0",
-        "doctrine/persistence": "^1.0",
+        "doctrine/persistence": "^1.3.4",
         "symfony/yaml": "~3.0 || ~4.0 || ~5.0",
         "symfony/routing": "~3.0 || ~4.0 || ~5.0",
         "pagerfanta/pagerfanta": "~1.0",

--- a/src/Util/ClassUtils.php
+++ b/src/Util/ClassUtils.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Hateoas\Util;
 
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Persistence\Proxy;
 
 class ClassUtils
 {


### PR DESCRIPTION
A backwards-compatibility layer has been added to persistence to help
consumers move to the new namespacing. It is based on class aliases,
which means the type declaration changes should not be a BC-break: types
are the same.
See doctrine/persistence#71

This means:
- using the new namespaces
- adding autoload calls for new types to types that may be extended and
use persistence types in type declarations of non-constructor methods,
so that signature compatibility is recognized by old versions of php. Luckily,
none of those were found in this package.

More details on this at
https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf