### PR TITLE
Allow doctrine/annotations > 1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.2 | ^8.0",
-        "doctrine/annotations": "~1.13.2",
+        "doctrine/annotations": "^1.13.2",
         "jms/metadata": "^2.0",
         "jms/serializer": "^3.2",
         "symfony/expression-language": "~3.0 || ~4.0 || ~5.0 || ~6.0"


### PR DESCRIPTION
I myself introduced the buggy version constraint in 449148d754c66e3622da7f0bf4e57679e0417c52