### PR TITLE
doctrine/coding-standard v12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7 | ^9.5.10",
-        "doctrine/coding-standard": "^5.0 | ^8.0",
+        "doctrine/coding-standard": "^12.0",
         "doctrine/persistence": "^1.3.4 | ^2.0 | ^3.0",
         "pagerfanta/core": "^2.4 || ^3.0",
         "phpdocumentor/type-resolver": "^1.5.1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -31,11 +31,16 @@
         <exclude name="SlevomatCodingStandard.ControlStructures.AssignmentInCondition.AssignmentInCondition"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
 
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLineDocComment.MultiLineDocComment"/>
         <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
 
         <exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator.RequiredNullCoalesceEqualOperator"/>
 
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming.SuperfluousSuffix"/>
+
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall.MissingTrailingComma"/>
+
+        <exclude name="SlevomatCodingStandard.PHP.RequireNowdoc.RequiredNowdoc"/>
 
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
@@ -96,10 +101,6 @@
     </rule>
 
     <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
-        <exclude-pattern>tests/*</exclude-pattern>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements">
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 

--- a/src/Configuration/Metadata/Driver/AnnotationDriver.php
+++ b/src/Configuration/Metadata/Driver/AnnotationDriver.php
@@ -28,7 +28,7 @@ class AnnotationDriver extends AnnotationOrAttributeDriver
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function getClassAnnotations(\ReflectionClass $class): array
     {

--- a/src/Configuration/Metadata/Driver/AttributeDriver.php
+++ b/src/Configuration/Metadata/Driver/AttributeDriver.php
@@ -7,7 +7,7 @@ namespace Hateoas\Configuration\Metadata\Driver;
 class AttributeDriver extends AnnotationOrAttributeDriver
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function getClassAnnotations(\ReflectionClass $class): array
     {

--- a/src/Configuration/Metadata/Driver/CheckExpressionTrait.php
+++ b/src/Configuration/Metadata/Driver/CheckExpressionTrait.php
@@ -16,7 +16,6 @@ trait CheckExpressionTrait
 
     /**
      * @param mixed $exp
-     * @param array $names
      *
      * @return Expression|mixed
      */

--- a/src/Configuration/Metadata/Driver/XmlDriver.php
+++ b/src/Configuration/Metadata/Driver/XmlDriver.php
@@ -178,7 +178,7 @@ class XmlDriver extends AbstractFileDriver
     {
         $embeddedExclusion = isset($embedded->exclusion) ? $this->parseExclusion($embedded->exclusion) : null;
         $xmlElementName = isset($embedded->attributes('')->{'xml-element-name'}) ? $this->checkExpression((string) $embedded->attributes('')->{'xml-element-name'}) : null;
-        $type = isset($embedded->attributes('')->{'type'}) ? $this->typeParser->parse((string) $embedded->attributes('')->{'type'}) : null;
+        $type = isset($embedded->attributes('')->type) ? $this->typeParser->parse((string) $embedded->attributes('')->type) : null;
 
         return new Embedded(
             $this->checkExpression((string) $embedded->content),

--- a/src/Configuration/Metadata/Driver/XmlDriver.php
+++ b/src/Configuration/Metadata/Driver/XmlDriver.php
@@ -41,6 +41,7 @@ class XmlDriver extends AbstractFileDriver
         ParserInterface $typeParser
     ) {
         parent::__construct($locator);
+
         $this->relationProvider = $relationProvider;
         $this->expressionLanguage = $expressionLanguage;
         $this->typeParser = $typeParser;

--- a/src/Configuration/Metadata/Driver/YamlDriver.php
+++ b/src/Configuration/Metadata/Driver/YamlDriver.php
@@ -40,6 +40,7 @@ class YamlDriver extends AbstractFileDriver
         ParserInterface $typeParser
     ) {
         parent::__construct($locator);
+
         $this->relationProvider = $relationProvider;
         $this->expressionLanguage = $expressionLanguage;
         $this->typeParser = $typeParser;

--- a/src/Configuration/Provider/ChainProvider.php
+++ b/src/Configuration/Provider/ChainProvider.php
@@ -24,7 +24,7 @@ class ChainProvider implements RelationProviderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getRelations(RelationProvider $configuration, string $class): array
     {

--- a/src/Configuration/Provider/ExpressionEvaluatorProvider.php
+++ b/src/Configuration/Provider/ExpressionEvaluatorProvider.php
@@ -20,7 +20,7 @@ class ExpressionEvaluatorProvider implements RelationProviderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getRelations(RelationProvider $configuration, string $class): array
     {

--- a/src/Configuration/Provider/FunctionProvider.php
+++ b/src/Configuration/Provider/FunctionProvider.php
@@ -9,7 +9,7 @@ use Hateoas\Configuration\RelationProvider;
 class FunctionProvider implements RelationProviderInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getRelations(RelationProvider $configuration, string $class): array
     {

--- a/src/Configuration/Provider/StaticMethodProvider.php
+++ b/src/Configuration/Provider/StaticMethodProvider.php
@@ -9,7 +9,7 @@ use Hateoas\Configuration\RelationProvider;
 class StaticMethodProvider implements RelationProviderInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getRelations(RelationProvider $configuration, string $class): array
     {

--- a/src/Configuration/Relation.php
+++ b/src/Configuration/Relation.php
@@ -39,7 +39,6 @@ class Relation
      * @param string|Expression $name
      * @param string|Route          $href
      * @param Embedded|string|mixed $embedded
-     * @param array                 $attributes
      */
     public function __construct(string $name, $href = null, $embedded = null, array $attributes = [], ?Exclusion $exclusion = null)
     {
@@ -71,9 +70,6 @@ class Relation
         return $this->href;
     }
 
-    /**
-     * @return array
-     */
     public function getAttributes(): array
     {
         return $this->attributes;

--- a/src/Expression/LinkExpressionFunction.php
+++ b/src/Expression/LinkExpressionFunction.php
@@ -11,8 +11,6 @@ class LinkExpressionFunction implements ExpressionFunctionProviderInterface
 {
     /**
      * @return ExpressionFunction[]
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      */
     public function getFunctions(): array
     {

--- a/src/Factory/EmbeddedsFactory.php
+++ b/src/Factory/EmbeddedsFactory.php
@@ -48,9 +48,6 @@ class EmbeddedsFactory
 
         if (null !== ($classMetadata = $this->metadataFactory->getMetadataForClass(get_class($object)))) {
             $langugeData = ['object' => $object, 'context' => $context];
-            /**
-             * @var $relation Relation
-             */
             foreach ($classMetadata->getRelations() as $relation) {
                 if ($this->exclusionManager->shouldSkipEmbedded($object, $relation, $context)) {
                     continue;
@@ -71,7 +68,6 @@ class EmbeddedsFactory
 
     /**
      * @param mixed $exp
-     * @param array $data
      *
      * @return mixed
      */

--- a/src/Factory/LinkFactory.php
+++ b/src/Factory/LinkFactory.php
@@ -75,7 +75,6 @@ class LinkFactory
 
     /**
      * @param mixed $exp
-     * @param array $data
      *
      * @return mixed
      */
@@ -88,12 +87,6 @@ class LinkFactory
         }
     }
 
-    /**
-     * @param array $array
-     * @param array $data
-     *
-     * @return array
-     */
     private function evaluateArray(array $array, array $data): array
     {
         $newArray = [];

--- a/src/Hateoas.php
+++ b/src/Hateoas.php
@@ -28,7 +28,7 @@ class Hateoas implements SerializerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function serialize($data, string $format, ?SerializationContext $context = null, ?string $type = null): string
     {
@@ -36,7 +36,7 @@ class Hateoas implements SerializerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function deserialize(string $data, string $type, string $format, ?DeserializationContext $context = null)
     {

--- a/src/HateoasBuilder.php
+++ b/src/HateoasBuilder.php
@@ -303,8 +303,6 @@ class HateoasBuilder
      * Set a map of namespace prefixes to directories.
      *
      * This method overrides any previously defined directories.
-     *
-     * @param array $namespacePrefixToDirMap
      */
     public function setMetadataDirs(array $namespacePrefixToDirMap): HateoasBuilder
     {
@@ -357,8 +355,6 @@ class HateoasBuilder
 
     /**
      * Add a map of namespace prefixes to directories.
-     *
-     * @param array $namespacePrefixToDirMap
      */
     public function addMetadataDirs(array $namespacePrefixToDirMap): HateoasBuilder
     {

--- a/src/Model/Link.php
+++ b/src/Model/Link.php
@@ -21,9 +21,6 @@ class Link
      */
     private $attributes;
 
-    /**
-     * @param array  $attributes
-     */
     public function __construct(string $rel, string $href, array $attributes = [])
     {
         $this->rel        = $rel;
@@ -31,9 +28,6 @@ class Link
         $this->attributes = $attributes;
     }
 
-    /**
-     * @return array
-     */
     public function getAttributes(): array
     {
         return $this->attributes;

--- a/src/Representation/AbstractSegmentedRepresentation.php
+++ b/src/Representation/AbstractSegmentedRepresentation.php
@@ -60,8 +60,6 @@ abstract class AbstractSegmentedRepresentation extends RouteAwareRepresentation
 
     /**
      * @param  null  $limit
-     *
-     * @return array
      */
     public function getParameters(?int $limit = null): array
     {

--- a/src/Representation/OffsetRepresentation.php
+++ b/src/Representation/OffsetRepresentation.php
@@ -94,8 +94,6 @@ class OffsetRepresentation extends AbstractSegmentedRepresentation
     /**
      * @param  null  $offset
      * @param  null  $limit
-     *
-     * @return array
      */
     public function getParameters(?int $offset = null, ?int $limit = null): array
     {

--- a/src/Representation/PaginatedRepresentation.php
+++ b/src/Representation/PaginatedRepresentation.php
@@ -109,8 +109,6 @@ class PaginatedRepresentation extends AbstractSegmentedRepresentation
     /**
      * @param  null  $page
      * @param  null  $limit
-     *
-     * @return array
      */
     public function getParameters($page = null, $limit = null): array
     {

--- a/src/Representation/RouteAwareRepresentation.php
+++ b/src/Representation/RouteAwareRepresentation.php
@@ -46,7 +46,6 @@ class RouteAwareRepresentation
 
     /**
      * @param mixed $inline
-     * @param array $parameters
      */
     public function __construct($inline, string $route, array $parameters = [], bool $absolute = false)
     {
@@ -69,9 +68,6 @@ class RouteAwareRepresentation
         return $this->route;
     }
 
-    /**
-     * @return array
-     */
     public function getParameters(): array
     {
         return $this->parameters;


### PR DESCRIPTION
This change makes it possible to install  `jms/serializer > 3.28` when running tests in the CI.