### PR TITLE
Make route annotation parameters default to array

### DIFF
--- a/src/Configuration/Annotation/Route.php
+++ b/src/Configuration/Annotation/Route.php
@@ -42,7 +42,7 @@ class Route
      * @param array|string $parameters
      * @param bool|string $absolute
      */
-    public function __construct($values = [], ?string $name = null, $parameters = null, $absolute = false, ?string $generator = null)
+    public function __construct($values = [], ?string $name = null, $parameters = [], $absolute = false, ?string $generator = null)
     {
         $this->loadAnnotationParameters(get_defined_vars());
     }


### PR DESCRIPTION
After the following change in the in the minor update from `3.10.0 -> 3.11.0`:
>[ **Add PHP 8 Attributes support**](https://github.com/willdurand/Hateoas/commit/fbae399fe7fb05cfe999ff21142343c00624ae37#diff-e56ac4e64eafc28bdd0b8c5d9081ef66eafc3c58eb7bcb496ea4f52e31bf5db8R43)

The parameter `$parameters` in [src/Configuration/Annotation/Route]( https://github.com/willdurand/Hateoas/blob/b2a3b1e5c6e68123a878f1c3f4472ec1e74a902c/src/Configuration/Annotation/Route.php#L45) is set to null by default instead of an array.

This leads to the following exception on routes that don't pass this parameter:
> The route parameters should be an array, NULL given. Maybe you forgot to wrap the expression in expr(...). 

Example:
```php
/**
 * @Hateoas\Relation(
 *      "self",
 *      href = @Hateoas\Route("api_example_route", absolute = true)
 * )
 */
```

But according the docs the `$parameters` are required and should default to an array, if not passed.
> [@Route](https://github.com/willdurand/Hateoas?tab=readme-ov-file#route)
> | Property    | Required             | Content         | Expression language         |
> |-------------|----------------------|-----------------|-----------------------------|
> | name        | Yes                  | string          | No                          |
> | parameters  | Defaults to array()  | array / string  | Yes (string + array values) |