### PR TITLE
Enhancement: Adds return types to `LinkExtension`

### DIFF
--- a/src/Twig/Extension/LinkExtension.php
+++ b/src/Twig/Extension/LinkExtension.php
@@ -23,7 +23,7 @@ class LinkExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('link_href', [$this->linkHelper, 'getLinkHref']),
@@ -33,7 +33,7 @@ class LinkExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'hateoas_link';
     }


### PR DESCRIPTION
This fixes deprecation logs like:

>  Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Hateoas\Twig\Extension\LinkExtension" now to avoid errors or add an explicit @return annotation to suppress this message. 