### PR TITLE
Enhancement: Adds return types on `ClassMetadata` serialization methods

### DIFF
--- a/src/Configuration/Metadata/ClassMetadata.php
+++ b/src/Configuration/Metadata/ClassMetadata.php
@@ -47,7 +47,7 @@ class ClassMetadata extends MergeableClassMetadata implements ClassMetadataInter
     /**
      * {@inheritDoc}
      */
-    public function serialize()
+    public function serialize(): string
     {
         return serialize([
             $this->relations,
@@ -58,7 +58,7 @@ class ClassMetadata extends MergeableClassMetadata implements ClassMetadataInter
     /**
      * {@inheritDoc}
      */
-    public function unserialize($str)
+    public function unserialize($str): void
     {
         [
             $this->relations,

--- a/src/Configuration/Metadata/ClassMetadata.php
+++ b/src/Configuration/Metadata/ClassMetadata.php
@@ -44,9 +44,6 @@ class ClassMetadata extends MergeableClassMetadata implements ClassMetadataInter
         $this->relations = array_merge($this->relations, $object->getRelations());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function serialize(): string
     {
         return serialize([


### PR DESCRIPTION
Fixes:

```
Method "Metadata\ClassMetadata::serialize()" might add "string" as a native return type declaration in the future. Do the same in child class "Hateoas\Configuration\Metadata\ClassMetadata" now to avoid errors or add an explicit @return annotation to suppress this message

Method "Metadata\ClassMetadata::unserialize()" might add "void" as a native return type declaration in the future. Do the same in child class "Hateoas\Configuration\Metadata\ClassMetadata" now to avoid errors or add an explicit @return annotation to suppress this message.
```