### PR TITLE
Add Support for Symfony 8 and drop outdated versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         dependencies:
           - "highest"
           - "lowest"
@@ -28,18 +29,15 @@ jobs:
           - "yes"
           - "no"
         symfony-require:
-          - "^3.0"
-          - "^4.0"
-          - "^5.0"
-          - "^6.0"
-          - "^7.0"
+          - "^5.4"
+          - "^6.4"
+          - "^7.3"
         exclude:
           - php-version: "8.1"
-            symfony-require: "^7.0"
-          - php-version: "8.4"
-            symfony-require: "^3.0"
-          - php-version: "8.4"
-            symfony-require: "^4.0"
+            symfony-require: "^7.3"
+        include:
+          - php-version: "8.5"
+            symfony-require: "^8.0"
 
     steps:
       - name: Checkout code
@@ -59,6 +57,11 @@ jobs:
           SYMFONY_REQUIRE: "${{ matrix.symfony-require }}"
         run: |
           composer remove --no-update --dev doctrine/annotations
+
+      # until Symfony 8 is released
+      - name: Configure Composer minimum stability
+        if: matrix.symfony-require == '^8.0'
+        run: composer config minimum-stability dev
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.1",
         "jms/metadata": "^2.0",
         "jms/serializer": "^3.18.2",
-        "symfony/expression-language": "^3.4.47 || ~4.0 || ~5.0 || ~6.0 || ~7.0"
+        "symfony/expression-language": "^5.4 || ^6.4 || ^7.3 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5.38",
@@ -31,8 +31,8 @@
         "phpdocumentor/type-resolver": "^1.5.1",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpspec/prophecy": "^1.16",
-        "symfony/routing": "^3.4.47 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
-        "symfony/yaml": "^3.4.47 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
+        "symfony/routing": "^5.4 || ^6.4 || ^7.3 || ^8.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.3 || ^8.0",
         "twig/twig": "^1.43 || ^2.13 || ^3.0"
     },
     "suggest": {


### PR DESCRIPTION
I don't think supporting Symfony 3, 4, and outdated (unsupported) minor version is needed anymore?

So I suggest to drop those + add support for Symfony 8